### PR TITLE
Export & Import SuperNeuroMAT models to/from an `.snn.json` file.

### DIFF
--- a/docs/source/api/SNN.rst
+++ b/docs/source/api/SNN.rst
@@ -211,6 +211,10 @@ Methods
    ~SNN.unmemoize
    ~SNN.zero_neuron_states
    ~SNN.zero_refractory_periods
+   ~SNN.rebuild_connection_ids
+   ~SNN.to_json
+   ~SNN.saveas_json
+   ~SNN.from_jsons
 
 
 Attributes

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -68,7 +68,7 @@ intersphinx_mapping = {
 
 
 html_theme = 'pydata_sphinx_theme'
-html_static_path = ['_static']
+html_static_path = ['_static', 'schema']
 html_title = "SuperNeuroMAT"
 
 github_version = "main"

--- a/docs/source/schema/0.1.0/snn.json
+++ b/docs/source/schema/0.1.0/snn.json
@@ -71,6 +71,6 @@
     },
   },
   "required": ["version", "networks"],
-  "additionalProperties": false,
+  "additionalProperties": false
 }
 

--- a/docs/source/schema/0.1.0/snn.json
+++ b/docs/source/schema/0.1.0/snn.json
@@ -1,0 +1,76 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ornl.github.io/superneuromat/schema/0.1.0/snn.json",
+  "title": "SuperNeuroMAT Networks Schema",
+  "description": "JSON file containing a list of networks for use with SuperNeuroMAT",
+  "type": "object",
+  "properties": {
+    "version": {
+      "description": "The version of the schema",
+      "type": "string",
+      "const": "0.1.0"
+    },
+    "networks": {
+      "description": "A list of networks",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "description": "The name of the network",
+            "type": "string"
+          },
+          "meta": {
+            "description": "Metadata about the network",
+            "type": "object",
+            "properties": {
+              "array_representation": {
+                "description": "The representation of the network data in the SNN",
+                "type": "string",
+                "enum": ["json-native", "base85", "base64"]
+              },
+              "from": {
+                "description": "The module and version used to create the network",
+                "type": "object",
+                "properties": {
+                  "module": {
+                    "description": "The module used to create the network",
+                    "type": "string"
+                  },
+                  "version": {
+                    "description": "The version of the module used to create the network",
+                    "type": "string"
+                  }
+                },
+                "required": ["module", "version"]
+              },
+              "format": {
+                "description": "The format of the network",
+                "type": "string",
+                "enum": ["snm"]
+              },
+              "format_version": {
+                "description": "The version of the format of the network",
+                "type": "string",
+                "const": "0.1.0"
+              }
+            },
+            "required": ["array_representation", "from", "format", "format_version"]
+          },
+          "data": {
+            "description": "The data of the network",
+            "type": "object"
+          },
+          "extra": {
+            "description": "Extra data about the network",
+            "type": "object"
+          }
+        },
+        "required": ["name", "meta", "data"]
+      }
+    },
+  },
+  "required": ["version", "networks"],
+  "additionalProperties": false,
+}
+

--- a/docs/source/schema/0.1/snn.json
+++ b/docs/source/schema/0.1/snn.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://ornl.github.io/superneuromat/schema/0.1.0/snn.json",
+  "$id": "https://ornl.github.io/superneuromat/schema/0.1/snn.json",
   "title": "SuperNeuroMAT Networks Schema",
   "description": "JSON file containing a list of networks for use with SuperNeuroMAT",
   "type": "object",
@@ -8,7 +8,7 @@
     "version": {
       "description": "The version of the schema",
       "type": "string",
-      "const": "0.1.0"
+      "const": "0.1"
     },
     "networks": {
       "description": "A list of networks",
@@ -66,7 +66,7 @@
             "type": "object"
           }
         },
-        "required": ["name", "meta", "data"]
+        "required": ["meta", "data"]
       }
     },
   },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -94,6 +94,7 @@ commands = [
     ["python", "test_display.py",],
     ["python", "test_reset.py",],
     ["python", "test_dtype.py",],
+    ["python", "test_json.py",],
 ]
 
 [tool.tox.env.jit]
@@ -157,6 +158,7 @@ commands = [
     ["python", "test_reset.py",],
     ["python", "test_dtype.py",],
     ["python", "test_spikes.py",],
+    ["python", "test_json.py",],
 ]
 
 [tool.tox.env.numpy20]
@@ -172,4 +174,5 @@ commands = [
     ["python", "test_reset.py",],
     ["python", "test_dtype.py",],
     ["python", "test_spikes.py",],
+    ["python", "test_json.py",],
 ]

--- a/src/superneuromat/json.py
+++ b/src/superneuromat/json.py
@@ -15,7 +15,7 @@ SIMPLE_LIST_ALLOWED_TYPES = (int, float)
 def _make_iterencode(markers, _default, _encoder, _indent, _floatstr,
         _key_separator, _item_separator, _sort_keys, _skipkeys, _one_shot,
         _simple_list_allowed_types,
-        ## HACK: hand-optimized bytecode; turn globals into locals
+        # HACK: hand-optimized bytecode; turn globals into locals
         ValueError=ValueError,
         dict=dict,
         float=float,
@@ -139,8 +139,11 @@ def _make_iterencode(markers, _default, _encoder, _indent, _floatstr,
             elif _skipkeys:
                 continue
             else:
-                raise TypeError(f'keys must be str, int, float, bool or None, '
-                                f'not {key.__class__.__name__}')
+                msg = (
+                    f'keys must be str, int, float, bool or None, '
+                    f'not {key.__class__.__name__}'
+                )
+                raise TypeError(msg)
             if first:
                 first = False
             else:
@@ -330,7 +333,7 @@ class JSONEncoder(_j.JSONEncoder):
         else:
             _encoder = _j.encoder.encode_basestring
 
-        c_make_encoder = _j.encoder.c_make_encoder
+        # c_make_encoder = _j.encoder.c_make_encoder
 
         if self.indent is None or isinstance(self.indent, str):
             indent = self.indent
@@ -347,6 +350,19 @@ class JSONEncoder(_j.JSONEncoder):
             self.key_separator, self.item_separator, self.sort_keys,
             self.skipkeys, _one_shot, self.compact_list_types)
         return _iterencode(o, 0)
+
+
+_default_encoder = JSONEncoder(
+    skipkeys=False,
+    ensure_ascii=True,
+    check_circular=True,
+    allow_nan=True,
+    indent=None,
+    separators=None,
+    default=None,
+    sort_keys=False,
+    compact_list_types=SIMPLE_LIST_ALLOWED_TYPES,
+)
 
 
 # from json, but with our new args added to docstring
@@ -402,7 +418,8 @@ def dump(obj, fp, *, skipkeys=False, ensure_ascii=True, check_circular=True,
     if (not skipkeys and ensure_ascii and
         check_circular and allow_nan and
         cls is None and indent is None and separators is None and
-        default is None and not sort_keys and not kw):
+        default is None and not sort_keys and compact_list_types == SIMPLE_LIST_ALLOWED_TYPES
+        and not kw):
         iterable = _default_encoder.iterencode(obj)
     else:
         if cls is None:
@@ -469,7 +486,8 @@ def dumps(obj, *, skipkeys=False, ensure_ascii=True, check_circular=True,
     if (not skipkeys and ensure_ascii and
         check_circular and allow_nan and
         cls is None and indent is None and separators is None and
-        default is None and not sort_keys and not kw):
+        default is None and not sort_keys and compact_list_types == SIMPLE_LIST_ALLOWED_TYPES
+        and not kw):
         return _default_encoder.encode(obj)
     if cls is None:
         cls = JSONEncoder

--- a/src/superneuromat/json.py
+++ b/src/superneuromat/json.py
@@ -1,0 +1,487 @@
+"""Modded Python JSON library
+
+Main changes:
+* ``float`` values are now exported with up to 999 decimal places
+* If indentation is enabled, lists will not indent every individual float
+"""
+
+import json as _j
+from functools import partial
+
+SIMPLE_LIST_ALLOWED_TYPES = (int, float)
+
+
+# from json.encoder's _make_iterencode
+def _make_iterencode(markers, _default, _encoder, _indent, _floatstr,
+        _key_separator, _item_separator, _sort_keys, _skipkeys, _one_shot,
+        _simple_list_allowed_types,
+        ## HACK: hand-optimized bytecode; turn globals into locals
+        ValueError=ValueError,
+        dict=dict,
+        float=float,
+        id=id,
+        int=int,
+        isinstance=isinstance,
+        list=list,
+        str=str,
+        tuple=tuple,
+        _intstr=int.__repr__,
+        all=all,
+    ):
+
+    # trying to continue _j.encoder's global -> local namespace hacking
+    # haven't tested if this actually speeds things up
+    simple_list_allowed_types = tuple(locals()[x.__name__] if x.__name__ in locals() else x
+                                 for x in _simple_list_allowed_types) if _simple_list_allowed_types else []
+
+    def is_simple_list(o, allowed_types=simple_list_allowed_types):
+        return all(isinstance(x, allowed_types) for x in o)
+
+    if _indent is not None and not isinstance(_indent, str):
+        _indent = ' ' * _indent
+
+    def _iterencode_list(lst, _current_indent_level):
+        if not lst:
+            yield '[]'
+            return
+        if markers is not None:
+            markerid = id(lst)
+            if markerid in markers:
+                raise ValueError("Circular reference detected")
+            markers[markerid] = lst
+        buf = '['
+        if _indent is None or (simple_list_allowed_types and is_simple_list(lst)):
+            newline_indent = None
+            separator = _item_separator
+        else:
+            _current_indent_level += 1
+            newline_indent = '\n' + _indent * _current_indent_level
+            separator = _item_separator + newline_indent
+            buf += newline_indent
+        first = True
+        for value in lst:
+            if first:
+                first = False
+            else:
+                buf = separator
+            if isinstance(value, str):
+                yield buf + _encoder(value)
+            elif value is None:
+                yield buf + 'null'
+            elif value is True:
+                yield buf + 'true'
+            elif value is False:
+                yield buf + 'false'
+            elif isinstance(value, int):
+                # Subclasses of int/float may override __repr__, but we still
+                # want to encode them as integers/floats in JSON. One example
+                # within the standard library is IntEnum.
+                yield buf + _intstr(value)
+            elif isinstance(value, float):
+                # see comment above for int
+                yield buf + _floatstr(value)
+            else:
+                yield buf
+                if isinstance(value, (list, tuple)):
+                    chunks = _iterencode_list(value, _current_indent_level)
+                elif isinstance(value, dict):
+                    chunks = _iterencode_dict(value, _current_indent_level)
+                else:
+                    chunks = _iterencode(value, _current_indent_level)
+                yield from chunks
+        if newline_indent is not None:
+            _current_indent_level -= 1
+            yield '\n' + _indent * _current_indent_level
+        yield ']'
+        if markers is not None:
+            del markers[markerid]
+
+    def _iterencode_dict(dct, _current_indent_level):
+        if not dct:
+            yield '{}'
+            return
+        if markers is not None:
+            markerid = id(dct)
+            if markerid in markers:
+                raise ValueError("Circular reference detected")
+            markers[markerid] = dct
+        yield '{'
+        if _indent is not None:
+            _current_indent_level += 1
+            newline_indent = '\n' + _indent * _current_indent_level
+            item_separator = _item_separator + newline_indent
+            yield newline_indent
+        else:
+            newline_indent = None
+            item_separator = _item_separator
+        first = True
+        if _sort_keys:
+            items = sorted(dct.items())
+        else:
+            items = dct.items()
+        for key, value in items:
+            if isinstance(key, str):
+                pass
+            # JavaScript is weakly typed for these, so it makes sense to
+            # also allow them.  Many encoders seem to do something like this.
+            elif isinstance(key, float):
+                # see comment for int/float in _make_iterencode
+                key = _floatstr(key)
+            elif key is True:
+                key = 'true'
+            elif key is False:
+                key = 'false'
+            elif key is None:
+                key = 'null'
+            elif isinstance(key, int):
+                # see comment for int/float in _make_iterencode
+                key = _intstr(key)
+            elif _skipkeys:
+                continue
+            else:
+                raise TypeError(f'keys must be str, int, float, bool or None, '
+                                f'not {key.__class__.__name__}')
+            if first:
+                first = False
+            else:
+                yield item_separator
+            yield _encoder(key)
+            yield _key_separator
+            if isinstance(value, str):
+                yield _encoder(value)
+            elif value is None:
+                yield 'null'
+            elif value is True:
+                yield 'true'
+            elif value is False:
+                yield 'false'
+            elif isinstance(value, int):
+                # see comment for int/float in _make_iterencode
+                yield _intstr(value)
+            elif isinstance(value, float):
+                # see comment for int/float in _make_iterencode
+                yield _floatstr(value)
+            else:
+                if isinstance(value, (list, tuple)):
+                    chunks = _iterencode_list(value, _current_indent_level)
+                elif isinstance(value, dict):
+                    chunks = _iterencode_dict(value, _current_indent_level)
+                else:
+                    chunks = _iterencode(value, _current_indent_level)
+                yield from chunks
+        if newline_indent is not None:
+            _current_indent_level -= 1
+            yield '\n' + _indent * _current_indent_level
+        yield '}'
+        if markers is not None:
+            del markers[markerid]
+
+    def _iterencode(o, _current_indent_level):
+        if isinstance(o, str):
+            yield _encoder(o)
+        elif o is None:
+            yield 'null'
+        elif o is True:
+            yield 'true'
+        elif o is False:
+            yield 'false'
+        elif isinstance(o, int):
+            # see comment for int/float in _make_iterencode
+            yield _intstr(o)
+        elif isinstance(o, float):
+            # see comment for int/float in _make_iterencode
+            yield _floatstr(o)
+        elif isinstance(o, (list, tuple)):
+            yield from _iterencode_list(o, _current_indent_level)
+        elif isinstance(o, dict):
+            yield from _iterencode_dict(o, _current_indent_level)
+        else:
+            if markers is not None:
+                markerid = id(o)
+                if markerid in markers:
+                    raise ValueError("Circular reference detected")
+                markers[markerid] = o
+            o = _default(o)
+            yield from _iterencode(o, _current_indent_level)
+            if markers is not None:
+                del markers[markerid]
+    return _iterencode
+
+
+class JSONEncoder(_j.JSONEncoder):
+    # modified to have our new args
+    def __init__(self, *, skipkeys=False, ensure_ascii=True,
+            check_circular=True, allow_nan=True, sort_keys=False,
+            indent=None, separators=None, default=None,
+            compact_list_types=SIMPLE_LIST_ALLOWED_TYPES,
+    ):
+        """Constructor for JSONEncoder, with sensible defaults.
+
+        If skipkeys is false, then it is a TypeError to attempt
+        encoding of keys that are not str, int, float or None.  If
+        skipkeys is True, such items are simply skipped.
+
+        If ensure_ascii is true, the output is guaranteed to be str
+        objects with all incoming non-ASCII characters escaped.  If
+        ensure_ascii is false, the output can contain non-ASCII characters.
+
+        If check_circular is true, then lists, dicts, and custom encoded
+        objects will be checked for circular references during encoding to
+        prevent an infinite recursion (which would cause an RecursionError).
+        Otherwise, no such check takes place.
+
+        If allow_nan is true, then NaN, Infinity, and -Infinity will be
+        encoded as such.  This behavior is not JSON specification compliant,
+        but is consistent with most JavaScript based encoders and decoders.
+        Otherwise, it will be a ValueError to encode such floats.
+
+        If sort_keys is true, then the output of dictionaries will be
+        sorted by key; this is useful for regression tests to ensure
+        that JSON serializations can be compared on a day-to-day basis.
+
+        If indent is a non-negative integer, then JSON array
+        elements and object members will be pretty-printed with that
+        indent level.  An indent level of 0 will only insert newlines.
+        None is the most compact representation.
+
+        If specified, separators should be an (item_separator, key_separator)
+        tuple.  The default is (', ', ': ') if *indent* is ``None`` and
+        (',', ': ') otherwise.  To get the most compact JSON representation,
+        you should specify (',', ':') to eliminate whitespace.
+
+        If specified, default is a function that gets called for objects
+        that can't otherwise be serialized.  It should return a JSON encodable
+        version of the object or raise a ``TypeError``.
+
+
+
+        """
+
+        self.skipkeys = skipkeys
+        self.ensure_ascii = ensure_ascii
+        self.check_circular = check_circular
+        self.allow_nan = allow_nan
+        self.sort_keys = sort_keys
+        self.indent = indent
+        if separators is not None:
+            self.item_separator, self.key_separator = separators
+        elif indent is not None:
+            self.item_separator = ','
+        if default is not None:
+            self.default = default
+
+        self.compact_list_types = compact_list_types
+
+    def float_repr(self, x):
+        s = f"{x:.999g}"
+        if '.' not in s:
+            if 'e' in s:
+                s = s.replace('e', '.e')
+            else:
+                s += '.0'
+        return s
+
+    def floatstr(self, o, allow_nan=None,
+                 _repr=None, _inf=_j.encoder.INFINITY, _neginf=-_j.encoder.INFINITY):
+        # Check for specials.  Note that this type of test is processor
+        # and/or platform-specific, so do tests which don't depend on the
+        # internals.
+
+        if allow_nan is None:
+            allow_nan = self.allow_nan
+
+        if _repr is None:
+            _repr = self.float_repr
+            # _repr = float.__repr__
+
+        if o != o:
+            text = 'NaN'
+        elif o == _inf:
+            text = 'Infinity'
+        elif o == _neginf:
+            text = '-Infinity'
+        else:
+            return _repr(o)
+
+        if not allow_nan:
+            raise ValueError(
+                "Out of range float values are not JSON compliant: " +
+                repr(o))
+
+        return text
+
+    def iterencode(self, o, _one_shot=False):
+        """Encode the given object and yield each string
+        representation as available.
+
+        For example::
+
+            for chunk in JSONEncoder().iterencode(bigobject):
+                mysocket.write(chunk)
+
+        """
+        # this is mostly copied from json.encoder, but with floatstr changed
+        if self.check_circular:
+            markers = {}
+        else:
+            markers = None
+        if self.ensure_ascii:
+            _encoder = _j.encoder.encode_basestring_ascii
+        else:
+            _encoder = _j.encoder.encode_basestring
+
+        c_make_encoder = _j.encoder.c_make_encoder
+
+        if self.indent is None or isinstance(self.indent, str):
+            indent = self.indent
+        else:
+            indent = ' ' * self.indent
+        # if _one_shot and c_make_encoder is not None:
+        #     _iterencode = c_make_encoder(
+        #         markers, self.default, _encoder, indent,
+        #         self.key_separator, self.item_separator, self.sort_keys,
+        #         self.skipkeys, self.allow_nan)
+        # else:
+        _iterencode = _make_iterencode(
+            markers, self.default, _encoder, indent, self.floatstr,
+            self.key_separator, self.item_separator, self.sort_keys,
+            self.skipkeys, _one_shot, self.compact_list_types)
+        return _iterencode(o, 0)
+
+
+# from json, but with our new args added to docstring
+def dump(obj, fp, *, skipkeys=False, ensure_ascii=True, check_circular=True,
+        allow_nan=True, cls=None, indent=None, separators=None,
+        default=None, sort_keys=False, compact_list_types=SIMPLE_LIST_ALLOWED_TYPES, **kw):
+    """Serialize ``obj`` as a JSON formatted stream to ``fp`` (a
+    ``.write()``-supporting file-like object).
+
+    If ``skipkeys`` is true then ``dict`` keys that are not basic types
+    (``str``, ``int``, ``float``, ``bool``, ``None``) will be skipped
+    instead of raising a ``TypeError``.
+
+    If ``ensure_ascii`` is false, then the strings written to ``fp`` can
+    contain non-ASCII characters if they appear in strings contained in
+    ``obj``. Otherwise, all such characters are escaped in JSON strings.
+
+    If ``check_circular`` is false, then the circular reference check
+    for container types will be skipped and a circular reference will
+    result in an ``RecursionError`` (or worse).
+
+    If ``allow_nan`` is false, then it will be a ``ValueError`` to
+    serialize out of range ``float`` values (``nan``, ``inf``, ``-inf``)
+    in strict compliance of the JSON specification, instead of using the
+    JavaScript equivalents (``NaN``, ``Infinity``, ``-Infinity``).
+
+    If ``indent`` is a non-negative integer, then JSON array elements and
+    object members will be pretty-printed with that indent level. An indent
+    level of 0 will only insert newlines. ``None`` is the most compact
+    representation.
+
+    If specified, ``separators`` should be an ``(item_separator, key_separator)``
+    tuple.  The default is ``(', ', ': ')`` if *indent* is ``None`` and
+    ``(',', ': ')`` otherwise.  To get the most compact JSON representation,
+    you should specify ``(',', ':')`` to eliminate whitespace.
+
+    ``default(obj)`` is a function that should return a serializable version
+    of obj or raise TypeError. The default simply raises TypeError.
+
+    If *sort_keys* is true (default: ``False``), then the output of
+    dictionaries will be sorted by key.
+
+    If *compact_list_types* is a non-empty tuple (default: ``(int, float)``),
+    and ``indent is not None`` then innermost-level
+    lists of these types will not be indented.
+
+    To use a custom ``JSONEncoder`` subclass (e.g. one that overrides the
+    ``.default()`` method to serialize additional types), specify it with
+    the ``cls`` kwarg; otherwise ``JSONEncoder`` is used.
+
+    """
+    # cached encoder
+    if (not skipkeys and ensure_ascii and
+        check_circular and allow_nan and
+        cls is None and indent is None and separators is None and
+        default is None and not sort_keys and not kw):
+        iterable = _default_encoder.iterencode(obj)
+    else:
+        if cls is None:
+            cls = JSONEncoder
+        iterable = cls(skipkeys=skipkeys, ensure_ascii=ensure_ascii,
+            check_circular=check_circular, allow_nan=allow_nan, indent=indent,
+            separators=separators, compact_list_types=compact_list_types,
+            default=default, sort_keys=sort_keys, **kw).iterencode(obj)
+    # could accelerate with writelines in some versions of Python, at
+    # a debuggability cost
+    for chunk in iterable:
+        fp.write(chunk)
+
+
+# from json, but with our new args added to docstring
+def dumps(obj, *, skipkeys=False, ensure_ascii=True, check_circular=True,
+        allow_nan=True, cls=None, indent=None, separators=None,
+        default=None, sort_keys=False, compact_list_types=SIMPLE_LIST_ALLOWED_TYPES, **kw):
+    """Serialize ``obj`` to a JSON formatted ``str``.
+
+    If ``skipkeys`` is true then ``dict`` keys that are not basic types
+    (``str``, ``int``, ``float``, ``bool``, ``None``) will be skipped
+    instead of raising a ``TypeError``.
+
+    If ``ensure_ascii`` is false, then the return value can contain non-ASCII
+    characters if they appear in strings contained in ``obj``. Otherwise, all
+    such characters are escaped in JSON strings.
+
+    If ``check_circular`` is false, then the circular reference check
+    for container types will be skipped and a circular reference will
+    result in an ``RecursionError`` (or worse).
+
+    If ``allow_nan`` is false, then it will be a ``ValueError`` to
+    serialize out of range ``float`` values (``nan``, ``inf``, ``-inf``) in
+    strict compliance of the JSON specification, instead of using the
+    JavaScript equivalents (``NaN``, ``Infinity``, ``-Infinity``).
+
+    If ``indent`` is a non-negative integer, then JSON array elements and
+    object members will be pretty-printed with that indent level. An indent
+    level of 0 will only insert newlines. ``None`` is the most compact
+    representation.
+
+    If specified, ``separators`` should be an ``(item_separator, key_separator)``
+    tuple.  The default is ``(', ', ': ')`` if *indent* is ``None`` and
+    ``(',', ': ')`` otherwise.  To get the most compact JSON representation,
+    you should specify ``(',', ':')`` to eliminate whitespace.
+
+    ``default(obj)`` is a function that should return a serializable version
+    of obj or raise TypeError. The default simply raises TypeError.
+
+    If *sort_keys* is true (default: ``False``), then the output of
+    dictionaries will be sorted by key.
+
+    If *compact_list_types* is a non-empty tuple (default: ``(int, float)``),
+    and ``indent is not None`` then innermost-level
+    lists of these types will not be indented.
+
+    To use a custom ``JSONEncoder`` subclass (e.g. one that overrides the
+    ``.default()`` method to serialize additional types), specify it with
+    the ``cls`` kwarg; otherwise ``JSONEncoder`` is used.
+
+    """
+    # cached encoder
+    if (not skipkeys and ensure_ascii and
+        check_circular and allow_nan and
+        cls is None and indent is None and separators is None and
+        default is None and not sort_keys and not kw):
+        return _default_encoder.encode(obj)
+    if cls is None:
+        cls = JSONEncoder
+    return cls(
+        skipkeys=skipkeys, ensure_ascii=ensure_ascii,
+        check_circular=check_circular, allow_nan=allow_nan, indent=indent,
+        separators=separators, default=default, sort_keys=sort_keys,
+        compact_list_types=compact_list_types,
+        **kw).encode(obj)
+
+
+detect_encoding = _j.detect_encoding
+
+load = _j.load
+loads = _j.loads

--- a/src/superneuromat/neuromorphicmodel.py
+++ b/src/superneuromat/neuromorphicmodel.py
@@ -2274,6 +2274,7 @@ class SNN:
             The indentation to use for the JSON.
             Set to ``None`` to get a compact JSON string.
 
+
         This function additionally accepts the same arguments as :py:meth:`json.dumps`.
 
         Returns
@@ -2312,6 +2313,7 @@ class SNN:
         indent : int, default=2
             The indentation to use for the JSON.
             Set to ``None`` to get a compact JSON string.
+
 
         This function additionally accepts the same arguments as :py:meth:`json.dump`.
 
@@ -2393,7 +2395,7 @@ class SNN:
 
     def from_jsons(self, json_str: str, net_id: int | str = 0,
                    skipkeys: list[str] | tuple[str] | None = None):
-        """Create a SNN from a SuperNeuroMat JSON string.
+        """Update this SNN from a SuperNeuroMat JSON string.
 
         Parameters
         ----------
@@ -2414,6 +2416,12 @@ class SNN:
         ------
         ValueError
             If network with given ID not found, or if multiple networks with the given ID are found.
+
+        Examples
+        --------
+        >>> snn = SNN()
+        >>> with open('my_model.snn.json', 'r') as f:
+        >>>     snn.from_jsons(f.read(), net_id="My SNN")
         """
         from . import json
 

--- a/src/superneuromat/neuromorphicmodel.py
+++ b/src/superneuromat/neuromorphicmodel.py
@@ -2223,13 +2223,13 @@ class SNN:
         networkd = {
             "meta": {
                 "array_representation": arep,
-                "from": {
+                "from": {  # We don't validate this right now.
                     "module": "superneuromat",
                     "version": snm_version,
                 },
                 "format": "snm",
-                "format_version": "0.1.0",
-                "type": self.__class__.__name__,
+                "format_version": "0.1.0",  # Not currently validating this
+                "type": self.__class__.__name__,  # differentiate from other snm network types
             },
             "data": data,
         }

--- a/src/superneuromat/neuromorphicmodel.py
+++ b/src/superneuromat/neuromorphicmodel.py
@@ -2227,7 +2227,7 @@ class SNN:
         json.JSONEncoder.default = default
 
         d = {
-            "$schema": "https://ornl.github.io/superneuromat/schema/0.1.0/snn.json",
+            "$schema": "https://ornl.github.io/superneuromat/schema/0.1/snn.json",
             "version": "0.1",
             "networks": [],
         }
@@ -2284,7 +2284,7 @@ class SNN:
         Examples
         --------
         >>> snn.to_json(net_name="My SNN", indent=None)
-        {"$schema": "https://ornl.github.io/superneuromat/schema/0.1.0/snn.json", "version": "0.1", "networks": [{"meta": {"array_representation": "json-native", "from": {"module": "superneuromat", "version": "3.1.0"}, "format": "snm", "format_version": "0.1", "type": "SNN"}, "data": {"neuron_refractory_periods": [0, 0], "neuron_states": [0.0, 0.0], "num_synapses": 2, "post_synaptic_neuron_ids": [1, 0], "aneg": [], "enable_stdp": [0, 0], "pre_synaptic_neuron_ids": [0, 1], "neuron_thresholds": [3.141592653589793115997963468544185161590576171875, 0.0], "neuron_refractory_periods_state": [0.0, 0.0], "neuron_reset_states": [0.0, 0.0], "stdp_positive_update": true, "input_spikes": {"3": {"nids": [1], "values": [1.0]}}, "synaptic_delays": [1, 1], "allow_signed_leak": false, "num_neurons": 2, "_sparse": "auto", "_backend": "auto", "apos": [], "manual_setup": false, "spike_train": [[1, 0], [0, 1], [0, 0], [0, 0], [0, 0], [0, 0], [0, 0], [0, 0], [0, 0], [0, 0]], "neuron_leaks": [Infinity, Infinity], "allow_incorrect_stdp_sign": false, "stdp": true, "synaptic_weights": [1.0, 1.0], "default_dtype": "float64", "stdp_negative_update": true}}]}
+        {"$schema": "https://ornl.github.io/superneuromat/schema/0.1/snn.json", "version": "0.1", "networks": [{"meta": {"array_representation": "json-native", "from": {"module": "superneuromat", "version": "3.1.0"}, "format": "snm", "format_version": "0.1", "type": "SNN"}, "data": {"neuron_refractory_periods": [0, 0], "neuron_states": [0.0, 0.0], "num_synapses": 2, "post_synaptic_neuron_ids": [1, 0], "aneg": [], "enable_stdp": [0, 0], "pre_synaptic_neuron_ids": [0, 1], "neuron_thresholds": [3.141592653589793115997963468544185161590576171875, 0.0], "neuron_refractory_periods_state": [0.0, 0.0], "neuron_reset_states": [0.0, 0.0], "stdp_positive_update": true, "input_spikes": {"3": {"nids": [1], "values": [1.0]}}, "synaptic_delays": [1, 1], "allow_signed_leak": false, "num_neurons": 2, "_sparse": "auto", "_backend": "auto", "apos": [], "manual_setup": false, "spike_train": [[1, 0], [0, 1], [0, 0], [0, 0], [0, 0], [0, 0], [0, 0], [0, 0], [0, 0], [0, 0]], "neuron_leaks": [Infinity, Infinity], "allow_incorrect_stdp_sign": false, "stdp": true, "synaptic_weights": [1.0, 1.0], "default_dtype": "float64", "stdp_negative_update": true}}]}
         """  # noqa: E501 (line length)
         d = self._to_json_dict(array_representation, skipkeys=skipkeys, net_name=net_name, extra=extra)
         return json.dumps(d, indent=indent, **kwargs)

--- a/tests/test_json.py
+++ b/tests/test_json.py
@@ -1,0 +1,117 @@
+import unittest
+
+import numpy as np
+
+import sys
+sys.path.insert(0, "../src/")
+
+from superneuromat import SNN
+
+use = 'cpu'
+
+
+class JSONTest(unittest.TestCase):
+    """ Test the JSON array export and import functions
+
+    """
+
+    def export_array(self, do_print=False):
+        from superneuromat import json
+        from math import pi
+
+        a = [1.0, 2, 3.3]
+        b = [True, False]
+        d = {'a': a, 'b': b, 'c': [b, b, pi]}
+        j = json.dumps(d, indent=4, separators=(', ', ': '))
+        if do_print:
+            print()
+            print(j)
+
+        return d, j
+
+    def test_export_array(self):
+        """Test exporting a custom formatted array to JSON"""
+
+        self.export_array(do_print=True)
+
+    def test_import_array(self):
+        """Test importing a custom formatted array from JSON
+
+        verify round-trip capability, including full float precision
+        """
+        from superneuromat import json
+
+        expected, j = self.export_array(do_print=False)
+
+        d = json.loads(j)
+
+        assert d == expected
+
+
+class JSONSNNTest(unittest.TestCase):
+    array_representation = "json-native"
+
+    def export_snn(self, do_print=False):
+        """Test exporting a SNN to JSON"""
+
+        snn = SNN()
+        import math
+
+        a = snn.create_neuron(threshold=math.pi)
+        b = snn.create_neuron()
+
+        snn.create_synapse(a, b)
+        snn.create_synapse(b, a)
+
+        a.add_spike(0, 5)
+
+        snn.simulate(10, use=use)
+
+        b.add_spike(3, 1)
+
+        s = snn.to_json(array_representation=self.array_representation)
+
+        if do_print:
+            print()
+            print(s)
+
+        return snn, s
+
+    def test_export_snn_str(self):
+        """Test exporting a SNN to JSON"""
+        print()
+        print("begin test_export_snn_str")
+        self.export_snn(do_print=True)
+
+    def test_import_snn_str(self):
+        """Test importing a SNN from JSON
+
+        verify round-trip capability
+        """
+        print("begin test_import_snn_str")
+        from superneuromat import json, SNN
+
+        snn, s = self.export_snn(do_print=False)
+
+        _j = json.loads(s)
+
+        print()
+        print(_j)
+
+        new = SNN()
+
+        new = new.from_jsons(s)
+
+        assert snn.__eq__(new, mismatch='raise')
+
+
+class JSONBase85SNNTest(JSONSNNTest):
+    array_representation = "base85"
+
+
+class JSONBase64SNNTest(JSONSNNTest):
+    array_representation = "base64"
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_json.py
+++ b/tests/test_json.py
@@ -15,14 +15,16 @@ class JSONTest(unittest.TestCase):
 
     """
 
-    def export_array(self, do_print=False):
+    def export_array(self, do_print=False, **kwargs):
         from superneuromat import json
         from math import pi
 
         a = [1.0, 2, 3.3]
         b = [True, False]
         d = {'a': a, 'b': b, 'c': [b, b, pi]}
-        j = json.dumps(d, indent=4, separators=(', ', ': '))
+        kwargs.setdefault('indent', 4)
+        kwargs.setdefault('separators', (', ', ': '))
+        j = json.dumps(d, **kwargs)
         if do_print:
             print()
             print(j)
@@ -51,7 +53,7 @@ class JSONTest(unittest.TestCase):
 class JSONSNNTest(unittest.TestCase):
     array_representation = "json-native"
 
-    def export_snn(self, do_print=False):
+    def export_snn(self, do_print=False, **kwargs):
         """Test exporting a SNN to JSON"""
 
         snn = SNN()
@@ -69,7 +71,7 @@ class JSONSNNTest(unittest.TestCase):
 
         b.add_spike(3, 1)
 
-        s = snn.to_json(array_representation=self.array_representation)
+        s = snn.to_json(array_representation=self.array_representation, **kwargs)
 
         if do_print:
             print()
@@ -83,6 +85,12 @@ class JSONSNNTest(unittest.TestCase):
         print("begin test_export_snn_str")
         self.export_snn(do_print=True)
 
+    def test_export_snn_str_indent_none(self):
+        """Test exporting a SNN to JSON"""
+        print()
+        print("begin test_export_snn_str_indent_none")
+        self.export_snn(do_print=True, indent=None)
+
     def test_import_snn_str(self):
         """Test importing a SNN from JSON
 
@@ -91,7 +99,7 @@ class JSONSNNTest(unittest.TestCase):
         print("begin test_import_snn_str")
         from superneuromat import json, SNN
 
-        snn, s = self.export_snn(do_print=False)
+        snn, s = self.export_snn(do_print=False, net_name="My SNN")
 
         _j = json.loads(s)
 
@@ -103,6 +111,12 @@ class JSONSNNTest(unittest.TestCase):
         new = new.from_jsons(s)
 
         assert snn.__eq__(new, mismatch='raise')
+
+        # test name
+        new = SNN().from_jsons(s, net_id="My SNN")
+        assert snn.__eq__(new, mismatch='raise')
+        self.assertRaises(ValueError, SNN().from_jsons, s, net_id="other")
+        self.assertRaises(IndexError, SNN().from_jsons, s, net_id=1)
 
 
 class JSONBase85SNNTest(JSONSNNTest):


### PR DESCRIPTION
Checked boxes are included in this pull request and ready to merge:
- [x] Exporting SNN to an `.snn.json` file
   - [x] Supports exporting to SuperNeuroMAT-specific format, i.e. LIF neurons. All SNN model details can be exported, including user options such as user-selected `_backend`/`_sparse` options, `allow_signed_leak`, etc.
   - [x] Exporting arrays in a human-readable `json-native` format with full precision.
   - [x] Export arrays in `base64` and `base85` formats.
   - [x] Users can optionally choose to omit portions of the model when exporting.
   - [x] Naming the network.
   - [ ] Exporting multiple networks to the same file
- [x] Importing a compatible `.snn.json` file
   - [x] Supports a network with the `snm` format and `SNN` class/type.
      - [x] `json-native` array format
      - [x] `base64` and `base85` array formats
   - [ ] Users can optionally ignore portions of the network (such as user options) when importing.
   - [ ] Support for SuperNeuroABM/NeuroCoreX formats
- [x] JSON schema for the format, to define a spec for the file format in no uncertain terms, and to allow for validation outside of superneuro
   - This is only partially completed, and hasn't been tested.
   - https://github.com/kenblu24/superneuromat/blob/53b63ef1424d63c0310fde13b184c38a3c44a1a9/docs/source/schema/0.1.0/snn.json
- [ ] Save model inputs/outputs list
- [x] Everything is well-documented, including being added to the `SNN` page
- [x] `tox` tests for importing/exporting 
   - https://github.com/kenblu24/superneuromat/blob/53b63ef1424d63c0310fde13b184c38a3c44a1a9/tests/test_json.py


<details><summary>Example JSON file, `json-native` array format</summary>
```json
{
  "$schema": "https://ornl.github.io/superneuromat/schema/0.1.0/snn.json",
  "version": "0.1.0",
  "networks": [
    {
      "meta": {
        "array_representation": "json-native",
        "from": {
          "module": "superneuromat",
          "version": "3.1.0"
        },
        "format": "snm",
        "format_version": "0.1.0",
        "type": "snm.SNN"
      },
      "data": {
        "neuron_reset_states": [0.0,0.0],
        "num_synapses": 2,
        "synaptic_delays": [1,1],
        "synaptic_weights": [1.0,1.0],
        "neuron_refractory_periods_state": [0.0,0.0],
        "_backend": "auto",
        "aneg": [],
        "num_neurons": 2,
        "input_spikes": {
          "3": {
            "nids": [1],
            "values": [1.0]
          }
        },
        "apos": [],
        "post_synaptic_neuron_ids": [1,0],
        "allow_incorrect_stdp_sign": false,
        "pre_synaptic_neuron_ids": [0,1],
        "neuron_states": [0.0,0.0],
        "allow_signed_leak": false,
        "spike_train": [
          [1,0],
          [0,1],
          [0,0],
          [0,0],
          [0,0],
          [0,0],
          [0,0],
          [0,0],
          [0,0],
          [0,0]
        ],
        "neuron_leaks": [Infinity,Infinity],
        "stdp_positive_update": true,
        "stdp_negative_update": true,
        "default_dtype": "float64",
        "neuron_thresholds": [3.141592653589793115997963468544185161590576171875,0.0],
        "stdp": true,
        "enable_stdp": [0,0],
        "_sparse": "auto",
        "manual_setup": false,
        "neuron_refractory_periods": [0,0]
      }
    }
  ]
}
```
</details> 

<details><summary>Example JSON file, `base85` format</summary>

```json
{
  "$schema": "https://ornl.github.io/superneuromat/schema/0.1.0/snn.json",
  "version": "0.1.0",
  "networks": [
    {
      "meta": {
        "array_representation": "base85",
        "from": {
          "module": "superneuromat",
          "version": "3.1.0"
        },
        "format": "snm",
        "format_version": "0.1.0",
        "type": "snm.SNN"
      },
      "data": {
        "neuron_reset_states": {
          "dtype": "<d",
          "original_type": "list",
          "base85": "00000000000000000000"
        },
        "num_synapses": 2,
        "synaptic_delays": {
          "dtype": "<d",
          "original_type": "list",
          "base85": "00000008hm00000008hm"
        },
        "synaptic_weights": {
          "dtype": "<d",
          "original_type": "list",
          "base85": "00000008hm00000008hm"
        },
        "neuron_refractory_periods_state": {
          "dtype": "<d",
          "original_type": "list",
          "base85": "00000000000000000000"
        },
        "_backend": "auto",
        "aneg": {
          "dtype": "|?",
          "original_type": "list",
          "base85": ""
        },
        "num_neurons": 2,
        "input_spikes": {
          "3": {
            "nids": [1],
            "values": [1.0]
          }
        },
        "apos": {
          "dtype": "|?",
          "original_type": "list",
          "base85": ""
        },
        "post_synaptic_neuron_ids": {
          "dtype": "<d",
          "original_type": "list",
          "base85": "00000008hm0000000000"
        },
        "allow_incorrect_stdp_sign": false,
        "pre_synaptic_neuron_ids": {
          "dtype": "<d",
          "original_type": "list",
          "base85": "000000000000000008hm"
        },
        "neuron_states": {
          "dtype": "<d",
          "original_type": "list",
          "base85": "00000000000000000000"
        },
        "allow_signed_leak": false,
        "spike_train": [
          [1,0],
          [0,1],
          [0,0],
          [0,0],
          [0,0],
          [0,0],
          [0,0],
          [0,0],
          [0,0],
          [0,0]
        ],
        "neuron_leaks": {
          "dtype": "<d",
          "original_type": "list",
          "base85": "00000008iR00000008iR"
        },
        "stdp_positive_update": true,
        "stdp_negative_update": true,
        "default_dtype": "float64",
        "neuron_thresholds": {
          "dtype": "<d",
          "original_type": "list",
          "base85": "7%fCp`ymNH0000000000"
        },
        "stdp": true,
        "enable_stdp": {
          "dtype": "|?",
          "original_type": "list",
          "base85": "000"
        },
        "_sparse": "auto",
        "manual_setup": false,
        "neuron_refractory_periods": {
          "dtype": "<d",
          "original_type": "list",
          "base85": "00000000000000000000"
        }
      }
    }
  ]
}
```
</details>

# Added functions

`rebuild_connection_ids` is a utility function which exists because I decided not to store this redundant information in the JSON, but rather rebuild it from the `pre_synaptic_neuron_ids` and `post_synaptic_neuron_ids`.

https://github.com/kenblu24/superneuromat/blob/8bb19cb42f64ef06130a1bca99ea146ca76d3c62/src/superneuromat/neuromorphicmodel.py#L2390

## Exporting

https://github.com/kenblu24/superneuromat/blob/8bb19cb42f64ef06130a1bca99ea146ca76d3c62/src/superneuromat/neuromorphicmodel.py#L2254-L2256

https://github.com/kenblu24/superneuromat/blob/8bb19cb42f64ef06130a1bca99ea146ca76d3c62/src/superneuromat/neuromorphicmodel.py#L2292-L2296

## Importing

https://github.com/kenblu24/superneuromat/blob/8bb19cb42f64ef06130a1bca99ea146ca76d3c62/src/superneuromat/neuromorphicmodel.py#L2394-L2396


# Changes

> [!warning]
> `SNN.eqvars` now includes `SNN.connection_ids`. This means that the `connection_ids` network parameter is checked when comparing two SNN instances for equality.