### PR TITLE
Improved accessor classes and Spike Deletion

### DIFF
--- a/docs/source/api/SNN.rst
+++ b/docs/source/api/SNN.rst
@@ -159,7 +159,7 @@ Methods
    ~SNN.get_synapse_df
    ~SNN.get_synapses_by_post
    ~SNN.get_synapses_by_pre
-   ~SNN.get_synapse_id
+   ~SNN.get_synaptic_id
    ~SNN.get_synaptic_ids_by_post
    ~SNN.get_synaptic_ids_by_pre
    ~SNN.get_weights_df

--- a/src/superneuromat/accessor_classes.py
+++ b/src/superneuromat/accessor_classes.py
@@ -176,6 +176,132 @@ class Neuron:
             if value != 0.0 or exist == 'overwrite':
                 self.add_spike(time + time_offset, value, exist=exist)
 
+    @property
+    def incoming_synapses(self) -> list[Synapse]:
+        """Returns a list of the synapses that have this neuron as their post-synaptic neuron."""
+        return self.m.get_synapses_by_post(self.idx)
+
+    @property
+    def incoming_synaptic_ids(self) -> list[int]:
+        """Returns a list of the synaptic ids of the synapses that have this neuron as their post-synaptic neuron."""
+        return self.m.get_synaptic_ids_by_post(self.idx)
+
+    @property
+    def outgoing_synapses(self) -> list[Synapse]:
+        """Returns a list of the synapses that have this neuron as their pre-synaptic neuron."""
+        return self.m.get_synapses_by_pre(self.idx)
+
+    @property
+    def outgoing_synaptic_ids(self) -> list[int]:
+        """Returns a list of the synaptic ids of the synapses that have this neuron as their pre-synaptic neuron."""
+        return self.m.get_synaptic_ids_by_pre(self.idx)
+
+    @property
+    def parents(self) -> list[Neuron]:
+        """Returns a list of the parent neurons of this neuron."""
+        return [syn.pre for syn in self.incoming_synapses]
+
+    @property
+    def parent_ids(self) -> list[int]:
+        """Returns a list of the IDs of the parent neurons of this neuron."""
+        return [syn.pre_id for syn in self.incoming_synapses]
+
+    @property
+    def children(self) -> list[Neuron]:
+        """Returns a list of the child neurons of this neuron."""
+        return [syn.post for syn in self.outgoing_synapses]
+
+    @property
+    def child_ids(self) -> list[int]:
+        """Returns a list of the IDs of the child neurons of this neuron."""
+        return [syn.post_id for syn in self.outgoing_synapses]
+
+    def get_synapse_to(self, neuron: int | Neuron) -> Synapse:
+        """Returns the synapse connecting this neuron to the given neuron (directional).
+
+        Parameters
+        ----------
+        neuron : Neuron | int
+            The neuron to which this neuron is connected.
+
+        Returns
+        -------
+        Synapse
+            The synapse connecting this neuron to the given neuron.
+
+        Raises
+        ------
+        TypeError
+            If `neuron` is not a Neuron or neuron ID (int).
+        IndexError
+            If no matching synapse is found.
+        """
+        return self.m.get_synapse(self.idx, neuron)
+
+    def get_synaptic_id_to(self, neuron: int | Neuron) -> int | None:
+        """Returns the synaptic id of the synapse connecting this neuron to the given neuron (directional).
+
+        Parameters
+        ----------
+        neuron : Neuron | int
+            The neuron to which this neuron is connected.
+
+        Returns
+        -------
+        int | None
+            The synaptic id of the synapse connecting this neuron to the given neuron.
+
+        Raises
+        ------
+        TypeError
+            If `neuron` is not a Neuron or neuron ID (int).
+        IndexError
+            If no matching synapse is found.
+        """
+        return self.m.get_synapse_id(self.idx, neuron)
+
+    def get_synapse_from(self, neuron: int | Neuron) -> Synapse:
+        """Returns the synapse connecting the given neuron to this neuron (directional).
+
+        Parameters
+        ----------
+        neuron : Neuron | int
+            The neuron which sends spikes to this neuron.
+
+        Returns
+        -------
+        Synapse
+            The synapse connecting the given neuron to this neuron.
+
+        Raises
+        ------
+        TypeError
+            If `neuron` is not a Neuron or neuron ID (int).
+        IndexError
+            If no matching synapse is found.
+        """
+        return self.m.get_synapse(neuron, self.idx)
+
+    def get_synaptic_id_from(self, neuron: int | Neuron) -> int | None:
+        """Returns the synaptic id of the synapse connecting the given neuron to this neuron (directional).
+
+        Parameters
+        ----------
+        neuron : Neuron | int
+            The neuron which sends spikes to this neuron.
+
+        Returns
+        -------
+        int | None
+            The synaptic id of the synapse connecting the given neuron to this neuron.
+
+        Raises
+        ------
+        TypeError
+            If `neuron` is not a Neuron or neuron ID (int).
+        """
+        return self.m.get_synaptic_id(neuron, self.idx)
+
     def connect_child(self, child, weight: float = 1.0, delay: int = 1, stdp_enabled: bool = False,
                       exist='error') -> Synapse:
         """Connect this neuron to a child neuron.

--- a/src/superneuromat/accessor_classes.py
+++ b/src/superneuromat/accessor_classes.py
@@ -524,6 +524,20 @@ class NeuronListView(list):
 
         snn.neurons[0]
         snn.neurons[1:10]
+
+    You can take a view of a view:
+
+    .. code-block:: python
+
+        snn.neurons[0:10][-5:]
+
+    You can add two views together. This will return a view of the concatenation of the two views.
+
+    However, if you add a view and something containing neurons from another model, or some
+    other type of object,the result will be a list.
+
+    Equivalence checking can be done between views and views, or views and an iterable.
+    In the latter case, element-wise equality is used.
     """
     def __init__(self, model: SNN, indices: list[int] | slice, max_len: int | None = None):
         self.m = model
@@ -590,7 +604,7 @@ class NeuronListView(list):
             last = [neuron.info_row() for neuron in self[-fi:]]
             rows = first + [Neuron.row_cont()] + last
         return '\n'.join([
-            f"Neuron Info ({len(self)}):",
+            f"NeuronListView on model at {hex(id(self.m))} ({len(self)}):",
             Neuron.row_header(),
             '\n'.join(rows),
         ])
@@ -799,6 +813,12 @@ class SynapseList:
 
         snn.synapses[0]
         snn.synapses[1:10]
+
+    You can take a view of a view:
+
+    .. code-block:: python
+
+        snn.synapses[0:10][-5:]
     """
     def __init__(self, model: SNN):
         self.m = model
@@ -816,6 +836,7 @@ class SynapseList:
             return SynapseListView(self.m, slice_indices(idx, self.m.num_synapses))
 
     def tolist(self):
+        """Convert the view to a list of synapses"""
         return list(self)
 
     def info(self, max_synapses=None):
@@ -852,6 +873,20 @@ class SynapseListView(list):
 
         snn.synapses[0]
         snn.synapses[1:10]
+
+    You can take a view of a view:
+
+    .. code-block:: python
+
+        snn.synapses[0:10][-5:]
+
+    You can add two views together. This will return a view of the concatenation of the two views.
+
+    However, if you add a view and something containing synapses from another model, or some
+    other type of object,the result will be a list.
+
+    Equivalence checking can be done between views and views, or views and an iterable.
+    In the latter case, element-wise equality is used.
     """
     def __init__(self, model: SNN, indices: list[int] | slice, max_len: int | None = None):
         self.m = model
@@ -918,7 +953,7 @@ class SynapseListView(list):
             last = [synapse.info_row() for synapse in self[-fi:]]
             rows = first + [Synapse.row_cont()] + last
         return '\n'.join([
-            f"Synapse Info ({len(self)}):",
+            f"SynapseListView on model at {hex(id(self.m))} ({len(self)}):",
             Synapse.row_header(),
             '\n'.join(rows),
         ])

--- a/src/superneuromat/neuromorphicmodel.py
+++ b/src/superneuromat/neuromorphicmodel.py
@@ -395,7 +395,7 @@ class SNN:
         msg = f"Synapse not found between neurons {pre_id} and {post_id}."
         raise IndexError(msg)
 
-    def get_synapse_id(self, pre_id: int | Neuron, post_id: int | Neuron) -> int | None:
+    def get_synaptic_id(self, pre_id: int | Neuron, post_id: int | Neuron) -> int | None:
         """Returns the id of the synapse connecting the given pre- and post-synaptic neurons.
 
         Parameters
@@ -421,6 +421,10 @@ class SNN:
         if not (is_intlike_catch(pre_id) and is_intlike_catch(post_id)):
             raise TypeError("pre_id and post_id must be int or Neuron.")
         return self.connection_ids.get((pre_id, post_id), None)
+
+    def get_synapse_id(self, pre_id: int | Neuron, post_id: int | Neuron) -> int | None:
+        """Alias to get_synaptic_id"""
+        return self.get_synaptic_id(pre_id, post_id)
 
     @property
     def stdp_time_steps(self) -> int:

--- a/src/superneuromat/neuromorphicmodel.py
+++ b/src/superneuromat/neuromorphicmodel.py
@@ -12,6 +12,7 @@ from scipy.sparse import csc_array  # scipy is also used for BLAS + numpy (dense
 from .util import getenv, getenvbool, is_intlike_catch, pretty_spike_train, int_err, float_err
 from . import json
 from .accessor_classes import Neuron, Synapse, NeuronList, SynapseList
+from .accessor_classes import NeuronListView, SynapseListView
 
 from typing import Any, TYPE_CHECKING
 
@@ -319,7 +320,7 @@ class SNN:
         list
             A list of :py:class:`Synapse`\\ s with the given pre-synaptic neuron. May be empty.
         """
-        return [self.synapses[i] for i in self.get_synaptic_ids_by_pre(pre_id)]
+        return SynapseListView(self, self.get_synaptic_ids_by_pre(pre_id))
 
     def get_synaptic_ids_by_post(self, post_id: int | Neuron) -> list[int]:
         """Returns a list of synapse ids with the given post-synaptic neuron.
@@ -363,7 +364,7 @@ class SNN:
         list
             A list of :py:class:`Synapse`\\ s with the given post-synaptic neuron. May be empty.
         """
-        return [self.synapses[i] for i in self.get_synaptic_ids_by_post(post_id)]
+        return SynapseListView(self, self.get_synaptic_ids_by_post(post_id))
 
     def get_synapse(self, pre_id: int | Neuron, post_id: int | Neuron) -> Synapse:
         """Returns the synapse that connects the given pre- and post-synaptic neurons.

--- a/tests/test_neuron.py
+++ b/tests/test_neuron.py
@@ -50,6 +50,29 @@ class NeuronTest(unittest.TestCase):
 
         print("test_accessor_create_synapse completed successfully")
 
+    def test_neuronlistview(self):
+        """ Test if NeuronListView works as expected """
+        print("begin test_neuronlistview")
+
+        snn = SNN()
+        a = snn.create_neuron()
+        b = snn.create_neuron()
+        c = snn.create_neuron()
+        d = snn.create_neuron()
+        e = snn.create_neuron()
+
+        print(snn.neurons[1:2])
+        assert len(snn.neurons[1:2]) == 1
+        assert snn.neurons[1:2][0] == b
+        assert snn.neurons[-3:].indices == [c.idx, d.idx, e.idx]
+        print(snn.neurons[a:b].indices)
+        assert snn.neurons[a:b] == [a]
+        assert a in snn.neurons
+        assert b in snn.neurons[0:3]
+        print(snn.neurons[0::2][-2:-1])
+
+
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_spikes.py
+++ b/tests/test_spikes.py
@@ -146,6 +146,42 @@ class SpikeTest(unittest.TestCase):
 
         snn.print_spike_train()
 
+    def test_delete_spikes(self):
+        """Test the clear_input_spikes function"""
+
+        print("begin test_delete_spikes")
+
+        snn = SNN()
+
+        a = snn.create_neuron()
+        b = snn.create_neuron()
+
+        b.add_spikes([1.0, 1.0])
+        a.add_spikes([
+            (5, 1.0),
+            (6, 1.0),
+            (7, 1.0),
+            (8, 1.0),
+            (9, 1.0),
+        ])
+        print(snn.input_spikes_info())
+        assert b.idx in snn.input_spikes[0]["nids"]
+
+        snn.clear_input_spikes(t=slice(3, 6))
+        snn.clear_input_spikes(t=8, destination=b)
+        snn.clear_input_spikes(t=[7])
+        snn.clear_input_spikes(t=np.array([6]), destination=[a])
+        snn.clear_input_spikes(destination=b)
+
+        def remove_empty(d: dict):
+            return {k: v for k, v in d.items() if v['nids'] and v['values']}
+
+        print(snn.input_spikes_info())
+        print(snn.input_spikes)
+        assert snn.input_spikes == {
+            8: {"nids": [0], "values": [1.0]},
+            9: {"nids": [0], "values": [1.0]},
+        }
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_synapse.py
+++ b/tests/test_synapse.py
@@ -141,6 +141,27 @@ class SynapseTest(unittest.TestCase):
 
         print("test_get_synapses completed successfully")
 
+    def test_neuron_get_synapses(self):
+        """ Test if the get_synapses functions are working properly. """
+        snn = SNN()
+
+        a = snn.create_neuron()
+        b = snn.create_neuron()
+        c = snn.create_neuron()
+
+        ab = snn.create_synapse(a, b, delay=1, stdp_enabled=True)
+        ac = snn.create_synapse(a, c, delay=2, stdp_enabled=True)
+
+        assert a.incoming_synapses == []
+        assert all([x == y for x, y in zip(a.incoming_synapses, snn.get_synapses_by_post(a))])
+        assert all([x == y for x, y in zip(a.outgoing_synapses, snn.get_synapses_by_pre(a))])
+        assert a.incoming_synapses == snn.get_synapses_by_post(a) == []
+        assert a.outgoing_synapses == snn.get_synapses_by_pre(a) == [ab, ac.delay_chain_synapses[0]]
+        assert b.parents == [a]
+        assert a.children == [b, ac.delay_chain[1]]
+        assert a.get_synapse_to(b) == ab
+        assert b.get_synapse_from(a) == ab
+
     def test_synapse_change_chained_delay(self):
         """ Test if error raised when changing delay on chained synapse
 
@@ -162,6 +183,7 @@ class SynapseTest(unittest.TestCase):
         """ Test if synapse delay chain properties work as expected
 
         """
+        print("begin test_synapse_get_delay_chain")
         # Create SNN, neurons, and synapses
         snn = SNN()
 
@@ -172,10 +194,10 @@ class SynapseTest(unittest.TestCase):
         neuron_chain = syn.delay_chain
         synapse_chain = syn.delay_chain_synapses
         print(snn)
-        print(neuron_chain)
+        print("neuron_chain: ", neuron_chain)
         print(*(syn.info_row() for syn in synapse_chain), sep='\n')
-        assert [int(n.idx) for n in neuron_chain] == [0, 2, 3, 1]
-        assert [int(s.idx) for s in synapse_chain] == [0, 1, 2]
+        assert [int(n) for n in neuron_chain] == [0, 2, 3, 1]
+        assert [int(s) for s in synapse_chain] == [0, 1, 2]
         assert snn.synapses[0].delay_chain == []
 
 


### PR DESCRIPTION
This pull request introduces `NeuronListView` and `SynapseListView`. These ListView objects provide first-class access to subsets of a model's `NeuronList` and `SynapseList`, respectively.

Implementation-wise, each ViewList contains an `indices: list[int]` parameter, which contains the indexes for the Neurons/Synapses inside.

These provide many convenient functions and much syntactical sugar to navigating an `SNN`.

All SNN and accessor methods now return a ViewList where appropriate.

Additionally, `Neuron`s  now have better methods for getting the associated `Synapse`s. There's a bit of an issue with how delay chain synapses are retrieved: The low-level pre/post synapses are found, which may cause unexpected behavior.

This pull request also adds features to `clear_input_spikes`, allowing users to only clear certain time steps, or certain destinations.