### PR TITLE
Accessors Overhaul

### DIFF
--- a/docs/source/api/Neuron.rst
+++ b/docs/source/api/Neuron.rst
@@ -5,3 +5,4 @@
 
 .. autoclass:: Neuron
    :members:
+   :inherited-members:

--- a/docs/source/api/NeuronListView.rst
+++ b/docs/source/api/NeuronListView.rst
@@ -1,0 +1,10 @@
+﻿superneuromat.NeuronListView
+==============================================
+
+.. currentmodule:: superneuromat
+
+.. autoclass:: NeuronListView
+   :members:
+   :inherited-members:
+   
+   

--- a/docs/source/api/SNN.rst
+++ b/docs/source/api/SNN.rst
@@ -159,6 +159,7 @@ Methods
    ~SNN.get_synapse_df
    ~SNN.get_synapses_by_post
    ~SNN.get_synapses_by_pre
+   ~SNN.get_synapse_id
    ~SNN.get_synaptic_id
    ~SNN.get_synaptic_ids_by_post
    ~SNN.get_synaptic_ids_by_pre

--- a/docs/source/api/Synapse.rst
+++ b/docs/source/api/Synapse.rst
@@ -5,4 +5,5 @@
 
 .. autoclass:: Synapse
    :members:
+   :inherited-members:
    

--- a/docs/source/api/SynapseListView.rst
+++ b/docs/source/api/SynapseListView.rst
@@ -1,0 +1,9 @@
+﻿superneuromat.SynapseListView
+===============================================
+
+.. currentmodule:: superneuromat
+
+.. autoclass:: SynapseListView
+   :members:
+   :inherited-members:
+   

--- a/docs/source/api/accessor_classes.NeuronList.rst
+++ b/docs/source/api/accessor_classes.NeuronList.rst
@@ -1,0 +1,9 @@
+﻿superneuromat.accessor\_classes.NeuronList
+==========================================
+
+.. currentmodule:: superneuromat.accessor_classes
+
+.. autoclass:: NeuronList
+   :members:
+   :inherited-members:
+   

--- a/docs/source/api/accessor_classes.SynapseList.rst
+++ b/docs/source/api/accessor_classes.SynapseList.rst
@@ -1,0 +1,9 @@
+﻿superneuromat.accessor\_classes.SynapseList
+===========================================
+
+.. currentmodule:: superneuromat.accessor_classes
+
+.. autoclass:: SynapseList
+   :members:
+   :inherited-members:
+   

--- a/docs/source/api/index.rst
+++ b/docs/source/api/index.rst
@@ -13,6 +13,10 @@ This is the API reference for the :py:mod:`superneuromat` package.
    SNN
    Neuron
    Synapse
+   accessor_classes.NeuronList
+   accessor_classes.SynapseList
+   NeuronListView
+   SynapseListView
 
 .. autosummary::
    :nosignatures:
@@ -20,12 +24,19 @@ This is the API reference for the :py:mod:`superneuromat` package.
    SNN
    Neuron
    Synapse
+   accessor_classes.NeuronList
+   accessor_classes.SynapseList
+   NeuronListView
+   SynapseListView
 
 .. autosummary::
    :toctree: _gen/
    :recursive:
 
-   ~accessor_classes.NeuronList
-   ~accessor_classes.SynapseList
+   ~accessor_classes.ModelAccessor
+   ~accessor_classes.ModelAccessorList
+   ~accessor_classes.ModelListView
+   ~accessor_classes.ModelListIterator
+   ~accessor_classes.ModelListViewIterator
    neuromorphicmodel
    util

--- a/src/superneuromat/__init__.py
+++ b/src/superneuromat/__init__.py
@@ -1,5 +1,6 @@
 from .neuromorphicmodel import SNN
 from .accessor_classes import Neuron, Synapse, ModelListView, mlist, asmlist
+from .accessor_classes import NeuronListView, SynapseListView
 from .util import is_intlike, pretty_spike_train, print_spike_train, getenvbool
 
 __all__ = [
@@ -7,6 +8,8 @@ __all__ = [
     "Neuron",
     "Synapse",
     "ModelListView",
+    "NeuronListView",
+    "SynapseListView",
     "mlist",
     "asmlist",
     "is_intlike",

--- a/src/superneuromat/accessor_classes.py
+++ b/src/superneuromat/accessor_classes.py
@@ -277,7 +277,7 @@ class ModelListView(MutableSequence):
                 cache.remove(self)
             except (ValueError, ReferenceError):
                 pass
-        if hasattr(self.m, self.model_cachename):
+        if hasattr(newmodel, self.model_cachename):
             cache = getattr(newmodel, self.model_cachename)
             if self not in cache:
                 cache.append(self)
@@ -373,15 +373,15 @@ class ModelListView(MutableSequence):
         for idx, x in zip(indices, new_indices):
             self.indices[idx] = x
 
-    def __delitem__(self, idx):
+    def __delitem__(self, idx_toremove):
         self._check_modify()
-        if isinstance(idx, (int, np.integer)):
-            del self.indices[int(idx)]
-        elif isinstance(idx, slice):
-            idx = slice_indices(idx, len(self))
-            self.indices = [i for i in self.indices if i not in idx]
+        if isinstance(idx_toremove, (int, np.integer)):
+            del self.indices[int(idx_toremove)]
+        elif isinstance(idx_toremove, slice):
+            idx_toremove = slice_indices(idx_toremove, len(self))
+            self.indices = [idx for i, idx in enumerate(self.indices) if i not in idx_toremove]
         else:
-            del self.indices[idx]  # raise error
+            del self.indices[idx_toremove]  # raise error
 
     def __eq__(self, x):
         if isinstance(x, self.listview_type):

--- a/src/superneuromat/accessor_classes.py
+++ b/src/superneuromat/accessor_classes.py
@@ -941,7 +941,7 @@ class NeuronListView(ModelListView):
 
     model_cachename = '_neuronlist_cache'
 
-    def __init__(self, model: SNN, indices: list[int] | slice, max_len: int | None = None):
+    def __init__(self, model: SNN, indices: list[int] | slice | None = None, max_len: int | None = None):
         self.accessor_type = Neuron
         self.list_type = NeuronList
         super().__init__(model, indices, max_len)
@@ -1188,7 +1188,7 @@ class SynapseListView(ModelListView):
 
     model_cachename = '_synapselist_cache'
 
-    def __init__(self, model: SNN, indices: list[int] | slice, max_len: int | None = None):
+    def __init__(self, model: SNN, indices: list[int] | slice | None = None, max_len: int | None = None):
         self.accessor_type = Synapse
         self.list_type = SynapseList
         super().__init__(model, indices, max_len)

--- a/src/superneuromat/accessor_classes.py
+++ b/src/superneuromat/accessor_classes.py
@@ -457,7 +457,7 @@ class ModelListView(MutableSequence):
 
         Parameters
         ----------
-        other : ModelListView | Sequence[NeuronAccessor] | Sequence[SynapseAccessor]
+        other : ModelListView | Sequence[Neuron] | Sequence[Synapse]
         right : bool, default=False
             Used for right-handed concatenation.
 
@@ -508,7 +508,7 @@ class ModelListView(MutableSequence):
 
         Parameters
         ----------
-        x : NeuronAccessor | SynapseAccessor
+        x : Neuron | Synapse
             The object to append to this ListView.
 
         Raises
@@ -535,7 +535,7 @@ class ModelListView(MutableSequence):
         ----------
         i : int
             The index at which to insert ``x``.
-        x : NeuronAccessor | SynapseAccessor
+        x : Neuron | Synapse
             The object to insert into this ListView.
 
         Raises
@@ -560,7 +560,7 @@ class ModelListView(MutableSequence):
 
         Parameters
         ----------
-        li : Sequence[NeuronAccessor] | Sequence[SynapseAccessor]
+        li : Sequence[Neuron] | Sequence[Synapse]
             The iterable of objects to extend this ListView with.
 
         Raises
@@ -591,7 +591,7 @@ class ModelListView(MutableSequence):
 
         Parameters
         ----------
-        value : NeuronAccessor | SynapseAccessor
+        value : Neuron | Synapse
             The item to remove from this ListView.
 
         Raises
@@ -630,7 +630,7 @@ class ModelListView(MutableSequence):
 
         Parameters
         ----------
-        value : NeuronAccessor | SynapseAccessor
+        value : Neuron | Synapse
         start : int, optional
             The starting index of the search, by default 0
         stop : _type_, optional
@@ -660,7 +660,7 @@ class ModelListView(MutableSequence):
 
         Parameters
         ----------
-        value : int | NeuronAccessor | SynapseAccessor
+        value : int | Neuron | Synapse
 
         Returns
         -------

--- a/src/superneuromat/accessor_classes.py
+++ b/src/superneuromat/accessor_classes.py
@@ -221,6 +221,7 @@ class ModelListView(list):
             indices = model.indices.copy()
             model = model.m
         self._model = None
+        # add to model cache if model is not None
         self.m = model
         self.indices: list[int]  # list of index values for the accessors on the SNN
         self.listview_type = type(self)
@@ -242,14 +243,13 @@ class ModelListView(list):
                     raise TypeError(msg) from err  # THIS IS NECESSARY FOR ModelAccessorList.__getitem__
             # normalize indices
             self.indices = [int(i) for i in indices]  # this converts accessor instances to their index values too
-        # check that indices are valid
-        if any(i for i in self.indices if not 0 <= i < self.num_onmodel):
-            msg = (f"{type(self)}.__init__() received {type(indices)} containing indices out of range "
-                    f"for SNN at {hex(id(self.m))} with {self.num_onmodel} neurons.")
-            raise IndexError(msg)
-        # add to model cache if model is not None
         if model:
             self.accessor_typename = self.accessor_type.__name__
+            # check that indices are valid
+            if any(i for i in self.indices if not 0 <= i < self.num_onmodel):
+                msg = (f"{type(self)}.__init__() received {type(indices)} containing indices out of range "
+                        f"for SNN at {hex(id(self.m))} with {self.num_onmodel} {self.accessor_typename.lower()}s.")
+                raise IndexError(msg)
 
     @property
     def m(self):
@@ -516,7 +516,7 @@ class ModelListView(list):
         Neuron | Synapse
             NeuronListViews will return Neurons, SynapseListViews will return Synapses.
         """
-        return self.m.neurons[self.indices.pop(index)]
+        return self.accessor_type(self.m, self.indices.pop(index))
 
     def index(self, value, start=0, stop=sys.maxsize):
         if isinstance(value, self.accessor_type):

--- a/src/superneuromat/accessor_classes.py
+++ b/src/superneuromat/accessor_classes.py
@@ -91,6 +91,14 @@ class ModelAccessor:
             return False
 
     def __hash__(self):
+        """Generate a hash for this object.
+
+        This hash is unique if the combination of the following is unique:
+
+        * the ``associated_typename`` of the object, i.e. ``"Neuron"`` or ``"Synapse"``
+        * the model instance that the object is associated with
+        * the index of the neuron or synapse that the object refers to
+        """
         return hash((self.associated_typename, self.idx, id(self.m)))
 
     def __repr__(self):
@@ -245,6 +253,11 @@ class ModelListView(list):
 
     @property
     def m(self):
+        """The :py:class:`SNN` that this object is associated with.
+
+        When setting this property, the object is moved from its current model to the new model,
+        if possible.
+        """
         return self._model
 
     @m.setter
@@ -490,6 +503,19 @@ class ModelListView(list):
             raise ValueError(self._verb_error("remove", self.accessor_typename, badtype=type(value).__name__))
 
     def pop(self, index=-1):
+        """Remove and return the last item, or the item at the given index.
+
+        Parameters
+        ----------
+        index : int, optional
+            The index (in this list) of the item to return
+            If not specified, the last item is returned.
+
+        Returns
+        -------
+        Neuron | Synapse
+            NeuronListViews will return Neurons, SynapseListViews will return Synapses.
+        """
         return self.m.neurons[self.indices.pop(index)]
 
     def index(self, value, start=0, stop=sys.maxsize):

--- a/src/superneuromat/accessor_classes.py
+++ b/src/superneuromat/accessor_classes.py
@@ -466,9 +466,8 @@ class Neuron(ModelAccessor):
 
     .. warning::
 
-        Instances of Neurons are created at access time and are not unique.
-        Multiple instances of this class may be created for the same neuron on the SNN.
-        To test for equality, use ``==`` instead of ``is``.
+        Instances of Neurons are cached at access time and ARE unique as of v3.4.0.
+        That is, each Neuron instance is a singleton.
 
     """
 
@@ -989,9 +988,8 @@ class Synapse(ModelAccessor):
 
     .. warning::
 
-        Instances of Synapse are created at access time and are not unique.
-        Multiple instances of this class may be created for the same synapse on the SNN.
-        To test for equality, use ``==`` instead of ``is``.
+        Instances of Synapse are cached at access time and ARE unique as of v3.4.0.
+        That is, each Synapse instance is a singleton.
 
     """
 

--- a/src/superneuromat/accessor_classes.py
+++ b/src/superneuromat/accessor_classes.py
@@ -45,7 +45,7 @@ class ModelAccessor:
                 cache[self.idx] = self
 
         if check_index:
-            self.check_index()
+            self._check_index()
 
     @property
     def m(self):
@@ -73,7 +73,7 @@ class ModelAccessor:
     def info(self):
         pass  # subclasses should define this  # pragma: no cover
 
-    def check_index(self):
+    def _check_index(self):
         if not (0 <= self.idx < self.num_onmodel):
             msg = (f"{self.associated_typename} index {self.idx} is out of range for {self.m.__class__.__name__} at "
                     f"{hex(id(self.m))} with {self.num_onmodel} {self.associated_typename.lower()}s.")

--- a/src/superneuromat/accessor_classes.py
+++ b/src/superneuromat/accessor_classes.py
@@ -15,6 +15,8 @@ else:
         def __repr__(self):
             return "SNN"
 
+_nonce = object()
+
 
 class ModelAccessor:
     """Accessor Class for SNNs"""
@@ -22,7 +24,8 @@ class ModelAccessor:
     associated_typename = ""
     model_cachename = ''
 
-    def __new__(cls, snn, idx: int, *args, **kwargs):
+    # when unpickling, Python will call __new__ without arguments
+    def __new__(cls, snn=_nonce, idx: int = _nonce, *args, **kwargs):
         if isinstance(idx, int) and hasattr(snn, cls.model_cachename):
             cache = getattr(snn, cls.model_cachename)
             if idx in cache:

--- a/src/superneuromat/accessor_classes.py
+++ b/src/superneuromat/accessor_classes.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 import sys
+from collections.abc import Sequence, MutableSequence
 from .util import is_intlike, int_err, accessor_slice, slice_indices
 
 from typing import TYPE_CHECKING, Any
@@ -109,8 +110,10 @@ class ModelAccessor:
         return f"<{self.associated_typename} {self.info()}>"
 
 
-class ModelAccessorList(list):
-    """Base class for :py:class:`NeuronList` and :py:class:`SynapseList`."""
+class ModelAccessorList(Sequence):
+    """Base class for :py:class:`NeuronList` and :py:class:`SynapseList`.
+
+    Inherits from :py:class:`collections.abc.Sequence`."""
     accessor_type: type
     listview_type: type
 
@@ -212,8 +215,10 @@ class ModelListViewIterator(ModelListIterator):
         return type(self)(self.m, self.indices)
 
 
-class ModelListView(list):
-    """Base class for :py:class:`NeuronListView` and :py:class:`SynapseListView`."""
+class ModelListView(MutableSequence):
+    """Base class for :py:class:`NeuronListView` and :py:class:`SynapseListView`.
+
+    Inherits from :py:class:`collections.abc.MutableSequence`."""
     accessor_type: type
     list_type: type
     model_cachename = ''
@@ -447,7 +452,7 @@ class ModelListView(list):
     def __str__(self):
         return self.info(None)
 
-    def __add__(self, other, right=False):
+    def add(self, other, right=False):
         """Concatenate this ListView with another iterable.
 
         Parameters
@@ -474,6 +479,8 @@ class ModelListView(list):
             me = list(self)
         indices_or_objs = other + me if right else me + other
         return self.listview_type(self.m, indices_or_objs) if view else list(indices_or_objs)
+
+    __add__ = add
 
     def __radd__(self, other):
         return self.__add__(other, right=True)

--- a/src/superneuromat/accessor_classes.py
+++ b/src/superneuromat/accessor_classes.py
@@ -49,6 +49,7 @@ class ModelAccessor:
 
     @property
     def m(self):
+        """The :py:class:`SNN` that this object is associated with."""
         return self._m
 
     @m.setter
@@ -109,6 +110,7 @@ class ModelAccessor:
 
 
 class ModelAccessorList(list):
+    """Base class for :py:class:`NeuronList` and :py:class:`SynapseList`."""
     accessor_type: type
     listview_type: type
 
@@ -211,6 +213,7 @@ class ModelListViewIterator(ModelListIterator):
 
 
 class ModelListView(list):
+    """Base class for :py:class:`NeuronListView` and :py:class:`SynapseListView`."""
     accessor_type: type
     list_type: type
     model_cachename = ''
@@ -494,6 +497,20 @@ class ModelListView(list):
             self.indices.append(x.idx)
 
     def remove(self, value):
+        """Remove the first occurrence of ``value`` from this ListView.
+
+        Parameters
+        ----------
+        value : NeuronAccessor | SynapseAccessor
+            The item to remove from this ListView.
+
+        Raises
+        ------
+        RuntimeError
+            If this ListView is not associated with an :py:class:`SNN`.
+        ValueError
+            If ``value`` is not present in this ListView.
+        """
         self._check_modify()
         if isinstance(value, self.accessor_type):
             if value.m is not self.m:
@@ -519,6 +536,26 @@ class ModelListView(list):
         return self.accessor_type(self.m, self.indices.pop(index))
 
     def index(self, value, start=0, stop=sys.maxsize):
+        """Return the index of ``value`` in this ListView.
+
+        Parameters
+        ----------
+        value : NeuronAccessor | SynapseAccessor
+        start : int, optional
+            The starting index of the search, by default 0
+        stop : _type_, optional
+            The ending index of the search (non-inclusive), by default sys.maxsize
+
+        Returns
+        -------
+        int
+            first index of ``value`` in this ListView.
+
+        Raises
+        ------
+        ValueError
+            if the value is not present.
+        """
         if isinstance(value, self.accessor_type):
             if value.m is not self.m:
                 raise ValueError(self._verb_error("index", self.accessor_typename, wrongmodel=value.m))
@@ -529,6 +566,20 @@ class ModelListView(list):
             raise ValueError(self._verb_error("index", self.accessor_typename, badtype=type(value).__name__))
 
     def count(self, value):
+        """Return the number of occurrences of ``value`` in this ListView.
+
+        Parameters
+        ----------
+        value : int | NeuronAccessor | SynapseAccessor
+
+        Returns
+        -------
+        int
+            The number of occurrences of ``value`` in this ListView.
+
+            If ``value`` can be cast to int (excluding :py:class:`ModelAccessor`\\ s), then
+            the number of occurrences of that index in the ListView.
+        """
         if isinstance(value, self.accessor_type) and value.m is self.m:
             return self.indices.count(value.idx)
         elif not isinstance(value, ModelAccessor) and is_intlike(value):
@@ -537,13 +588,27 @@ class ModelListView(list):
             return 0
 
     def copy(self, model=None):
+        """Create a copy of this ListView with the same indices, referring to the same :py:class:`SNN`."""
         return type(self)(model or self.m, self.indices.copy())
 
     def reverse(self):
+        """Reverse the order of the items in this ListView."""
         self._check_modify()
         return self.indices.reverse()
 
     def sort(self, key=None, reverse=False):
+        """Sort the items in this ListView.
+
+        Parameters
+        ----------
+        key : callable | None, default=None
+            A function to be called on each item in the ListView.
+            The function should take a single argument, which will be the item from the ListView,
+            and return a value that will be used for sorting.
+            If ``None``, the items will be sorted by its index in the :py:class:`SNN`.
+        reverse : bool, default=False
+            If ``True``, the items will be sorted in descending order.
+        """
         self._check_modify()
         if callable(key):
             indices = self.indices.copy()

--- a/src/superneuromat/accessor_classes.py
+++ b/src/superneuromat/accessor_classes.py
@@ -466,8 +466,9 @@ class Neuron(ModelAccessor):
 
     .. warning::
 
-        Instances of Neurons are cached at access time and ARE unique as of v3.4.0.
-        That is, each Neuron instance is a singleton.
+        Instances of Neurons are cached at access time as of v3.4.0.
+        i.e. ``snn.neurons[0] is snn.neurons[0]``.
+        Prior to v3.4.0, new Neuron instances were created on each access.
 
     """
 
@@ -988,8 +989,9 @@ class Synapse(ModelAccessor):
 
     .. warning::
 
-        Instances of Synapse are cached at access time and ARE unique as of v3.4.0.
-        That is, each Synapse instance is a singleton.
+        Instances of Synapse are cached at access time as of v3.4.0.
+        i.e. ``snn.synapses[0] is snn.synapses[0]``.
+        Prior to v3.4.0, new Synapse instances were created on each access.
 
     """
 

--- a/src/superneuromat/accessor_classes.py
+++ b/src/superneuromat/accessor_classes.py
@@ -228,9 +228,7 @@ class ModelListView(MutableSequence):
             assert max_len is None
             indices = model.indices.copy()
             model = model.m
-        self._model = None
-        # add to model cache if model is not None
-        self.m = model
+        self._model = model
         self.indices: list[int]  # list of index values for the accessors on the SNN
         self.listview_type = type(self)
         if model is None and indices:
@@ -258,6 +256,11 @@ class ModelListView(MutableSequence):
                 msg = (f"{type(self)}.__init__() received {type(indices)} containing indices out of range "
                         f"for SNN at {hex(id(self.m))} with {self.num_onmodel} {self.accessor_typename.lower()}s.")
                 raise IndexError(msg)
+        # add to model cache if model is not None
+        if hasattr(model, self.model_cachename):
+            cache = getattr(model, self.model_cachename)
+            if self not in cache:
+                cache.append(self)
 
     @property
     def m(self):

--- a/src/superneuromat/accessor_classes.py
+++ b/src/superneuromat/accessor_classes.py
@@ -105,7 +105,7 @@ class ModelAccessorList(list):
         self.accessor_typename = self.accessor_type.__name__
 
     def __getitem__(self, idx):
-        if isinstance(idx, (int, self.accessor_type)):
+        if isinstance(idx, (int, np.integer, self.accessor_type)):
             return self.accessor_type(self.m, int(idx))
         if idx is None:
             raise TypeError("list indices cannot be NoneType.")
@@ -136,7 +136,7 @@ class ModelAccessorList(list):
     def __contains__(self, item):
         if isinstance(item, self.accessor_type):
             return 0 <= item.idx < self.num_onmodel and self.m is item.m
-        elif isinstance(item, int):
+        elif isinstance(item, (int, np.integer)):
             return 0 <= item < self.num_onmodel
         return False
 
@@ -224,7 +224,7 @@ class ModelListView(list):
             raise IndexError(msg)
 
     def __getitem__(self, idx):
-        if isinstance(idx, int):
+        if isinstance(idx, (int, np.integer)):
             return Neuron(self.m, self.indices[idx])
         elif isinstance(idx, self.accessor_type) and idx.m is self.m:
             return idx
@@ -252,7 +252,7 @@ class ModelListView(list):
                 raise ValueError(msg)
             return int(value)
 
-        if isinstance(idx, int):
+        if isinstance(idx, (int, np.integer)):
             check_value(value)
             self.indices[idx] = value.idx
             return
@@ -290,7 +290,7 @@ class ModelListView(list):
 
     def __delitem__(self, idx):
         self._check_modify()
-        if isinstance(idx, (int, self.accessor_type)):
+        if isinstance(idx, (int, np.integer, self.accessor_type)):
             del self.indices[int(idx)]
         elif isinstance(idx, slice):
             idx = slice_indices(idx, len(self))
@@ -312,7 +312,7 @@ class ModelListView(list):
     def __contains__(self, idx):
         if isinstance(idx, self.accessor_type):
             return idx.idx in self.indices and self.m is idx.m
-        elif isinstance(idx, int):
+        elif isinstance(idx, (int, np.integer)):
             return idx in self.indices
         return False
 

--- a/src/superneuromat/neuromorphicmodel.py
+++ b/src/superneuromat/neuromorphicmodel.py
@@ -2539,3 +2539,20 @@ class SNN:
             raise NotImplementedError("net_id must be int or str. Importing multiple networks is not supported yet.")
 
         return self.from_json_network(net_dict, skipkeys=skipkeys)
+
+    # deal with weakrefs not being picklable
+    def __getstate__(self):
+        d = self.__dict__.copy()
+        d['_neuron_cache'] = dict(self._neuron_cache)
+        d['_synapse_cache'] = dict(self._synapse_cache)
+        d['_neuronlist_cache'] = list(self._neuronlist_cache)
+        d['_synapselist_cache'] = list(self._synapselist_cache)
+        return d
+
+    # see my comments: https://stackoverflow.com/a/45588812/2712730
+    def __setstate__(self, d):
+        self.__dict__.update(d)
+        self._neuron_cache = WeakValueDictionary(d['_neuron_cache'])
+        self._synapse_cache = WeakValueDictionary(d['_synapse_cache'])
+        self._neuronlist_cache = WeakProxyList(d['_neuronlist_cache'])
+        self._synapselist_cache = WeakProxyList(d['_synapselist_cache'])

--- a/src/superneuromat/neuromorphicmodel.py
+++ b/src/superneuromat/neuromorphicmodel.py
@@ -405,6 +405,11 @@ class SNN:
     def get_synaptic_id(self, pre_id: int | Neuron, post_id: int | Neuron) -> int | None:
         """Returns the id of the synapse connecting the given pre- and post-synaptic neurons.
 
+        .. toctree::
+            :hidden:
+
+            /api/_gen/superneuromat.SNN.get_synapse_id.rst
+
         Parameters
         ----------
         pre_id : int | Neuron, required
@@ -420,6 +425,11 @@ class SNN:
         ------
         TypeError
             If `pre_id` or `post_id` is not a Neuron or neuron ID (int).
+
+
+        See Also
+        --------
+        SNN.get_synapse_id
         """
         if isinstance(pre_id, Neuron):
             pre_id = pre_id.idx
@@ -430,7 +440,7 @@ class SNN:
         return self.connection_ids.get((pre_id, post_id), None)
 
     def get_synapse_id(self, pre_id: int | Neuron, post_id: int | Neuron) -> int | None:
-        """Alias to get_synaptic_id"""
+        """Alias to :py:meth:`get_synaptic_id`."""
         return self.get_synaptic_id(pre_id, post_id)
 
     @property

--- a/src/superneuromat/neuromorphicmodel.py
+++ b/src/superneuromat/neuromorphicmodel.py
@@ -6,16 +6,17 @@ import math
 import copy
 import warnings
 import numpy as np
-from numpy import typing as npt
 from textwrap import dedent
+from weakref import WeakValueDictionary
+from numpy import typing as npt
 from scipy.sparse import csc_array  # scipy is also used for BLAS + numpy (dense matrix)
 from .util import getenv, getenvbool, is_intlike_catch, int_err, float_err
-from .util import pretty_spike_train, slice_indices
+from .util import pretty_spike_train, slice_indices, WeakProxyList
 from . import json
 from .accessor_classes import Neuron, Synapse, NeuronList, SynapseList
 from .accessor_classes import NeuronListView, SynapseListView
 
-from typing import Any, TYPE_CHECKING
+from typing import Any, TYPE_CHECKING, Sequence
 
 try:
     import numba
@@ -133,6 +134,10 @@ class SNN:
 
         self.neurons = NeuronList(self)
         self.synapses = SynapseList(self)
+        self._neuron_cache = WeakValueDictionary()
+        self._synapse_cache = WeakValueDictionary()
+        self._neuronlist_cache = WeakProxyList()
+        self._synapselist_cache = WeakProxyList()
         self.connection_ids = {}
 
         self.gpu = GPU_AVAILABLE

--- a/src/superneuromat/util.py
+++ b/src/superneuromat/util.py
@@ -10,6 +10,7 @@
 """
 from __future__ import annotations
 import os
+from weakref import proxy
 
 import numpy as np
 
@@ -154,6 +155,11 @@ def slice_indices(s: slice[Any, Any, Any], max_len: int = 0) -> list[int]:
     else:  # step is negative, stop is not None. Ignore stop
         stop = max_len
     return list(range(stop))[s]
+
+
+class WeakProxyList(list):
+    def append(self, x):
+        super().append(proxy(x))
 
 
 def pretty_spike_train(

--- a/src/superneuromat/util.py
+++ b/src/superneuromat/util.py
@@ -158,6 +158,10 @@ def slice_indices(s: slice[Any, Any, Any], max_len: int = 0) -> list[int]:
 
 
 class WeakProxyList(list):
+    def __init__(self, x=None):
+        x = [] if x is None else x
+        super().__init__([proxy(y) for y in x])  # this is used when unpickling
+
     def append(self, x):
         super().append(proxy(x))
 

--- a/tests/test_neuron.py
+++ b/tests/test_neuron.py
@@ -208,7 +208,7 @@ class NeuronTest(unittest.TestCase):
         assert l1.index(2) == 2
         l4 = mlist([b, c, c, d, d, d])
         assert l4.index(c) == 1
-        assert l4.index(c, start=2) == 2
+        assert l4.index(c, start=2, stop=3) == 2
         with self.assertRaises(ValueError):
             l4.index(c, start=3)
         with self.assertRaises(ValueError):

--- a/tests/test_neuron.py
+++ b/tests/test_neuron.py
@@ -6,6 +6,7 @@ import sys
 sys.path.insert(0, "../src/")
 
 from superneuromat import SNN, mlist, asmlist, NeuronListView
+from superneuromat.accessor_classes import NeuronIterator, NeuronViewIterator
 
 
 class NeuronTest(unittest.TestCase):
@@ -26,6 +27,17 @@ class NeuronTest(unittest.TestCase):
 
         print(a)
         print(repr(a))
+
+    def test_neurons_iter(self):
+        """ Test if Neuron iterator works as expected """
+        print("begin test_neurons_iter")
+        snn = SNN()
+
+        neurons = mlist([snn.create_neuron(threshold=i) for i in range(3)])
+
+        it = NeuronIterator(snn)
+        li = list(it)
+        assert len(li) == 3
 
     def test_accessor_change_model(self):
         """ Test if Neuron model change works as expected """

--- a/tests/test_neuron.py
+++ b/tests/test_neuron.py
@@ -1,16 +1,51 @@
+from collections import deque
 import numpy as np
 import unittest
 
 import sys
 sys.path.insert(0, "../src/")
 
-from superneuromat import SNN, mlist, asmlist
+from superneuromat import SNN, mlist, asmlist, NeuronListView
 
 
 class NeuronTest(unittest.TestCase):
     """ Test all type errors
 
     """
+
+    def test_neuron_accessor(self):
+        """ Test if Neuron works as expected """
+        print("begin test_neuron_accessor")
+        snn = SNN()
+        a = snn.create_neuron()
+        b = snn.create_neuron()
+
+        assert a.idx == 0
+        assert not a == 0
+        assert a != b
+
+        print(a)
+        print(repr(a))
+
+    def test_accessor_change_model(self):
+        """ Test if Neuron model change works as expected """
+
+        snn = SNN()
+        a = snn.create_neuron()
+        b = snn.create_neuron()
+        c = snn.create_neuron()
+
+        snn2 = SNN()
+        a2 = snn2.create_neuron()
+        b2 = snn2.create_neuron()
+
+        assert a in snn.neurons
+        assert b in snn.neurons
+        assert a2 in snn2.neurons
+        assert b2 in snn2.neurons
+
+        a.m = snn2
+        c.m = snn2
 
     def test_create_neuron_errors(self):
         """ Test input validation for create_neuron()
@@ -55,21 +90,45 @@ class NeuronTest(unittest.TestCase):
         print("begin test_neuronlist")
         snn = SNN()
 
+        assert snn.neurons == []
+        assert not snn.neurons
+
         a = snn.create_neuron()
         b = snn.create_neuron()
         c = snn.create_neuron()
 
+        snn2 = SNN()
+        a2 = snn2.create_neuron()
+
+        assert snn.neurons
         assert len(snn.neurons) == 3
         assert snn.neurons[0] == a
         assert snn.neurons[1] == b
         assert snn.neurons[2] == c
+        assert snn.neurons[a].idx == 0
+        assert a in snn.neurons
+        assert a2 not in snn.neurons
+        assert 1 in snn.neurons
+        assert 3 not in snn.neurons
+        assert None not in snn.neurons
         with self.assertRaises(IndexError):
             snn.neurons[3]
-        assert snn.neurons[2:4]
+        assert snn.neurons[2:4] == [c]
+        assert snn.neurons[[1, 2]] == [b, c]  # pyright: ignore[reportArgumentType]
         assert not snn.neurons[3:4]
+        assert snn.neurons != []  # make sure it's not empty (since we're subclassing list)
+        assert snn.neurons is snn.neurons
+        assert snn.neurons == snn.neurons
+        assert snn.neurons != snn2.neurons
         assert snn.neurons == [a, b, c]
+        assert snn.neurons[a] == a
+        assert not (snn.neurons != [a, b, c])
+        assert snn.neurons == deque([a, b, c])  # test funky non-list ordered iterable
+        assert snn.neurons != {a, b, c, a2}
+        assert snn.neurons != None  # noqa: E711  # note that this won't use __eq__
         assert snn.neurons.tolist() == [a, b, c]
         assert snn.neurons[:] == [a, b, c]
+        assert snn.neurons == snn.neurons[:]
         assert snn.neurons[:0:-1] == [c, b]
         assert snn.neurons[:].indices == snn.neurons.indices
         with self.assertRaises(ValueError):
@@ -77,17 +136,25 @@ class NeuronTest(unittest.TestCase):
         with self.assertRaises(TypeError):
             snn.neurons[None]  # pyright: ignore[reportArgumentType]
 
+        print(snn.neurons)
+        print(repr(snn.neurons))
+
     def test_neuronlistview(self):
         """ Test if NeuronListView works as expected """
         print("begin test_neuronlistview")
 
         snn = SNN()
+
+        assert not snn.neurons[:]
+        assert snn.neurons[:] == []
+
         a = snn.create_neuron()
         b = snn.create_neuron()
         c = snn.create_neuron()
         d = snn.create_neuron()
         e = snn.create_neuron()
 
+        assert snn.neurons[:]
         print(snn.neurons[1:2])
         assert len(snn.neurons[1:2]) == 1
         assert snn.neurons[1:2][0] == b
@@ -96,9 +163,83 @@ class NeuronTest(unittest.TestCase):
         assert snn.neurons[a:b] == [a]
         assert a in snn.neurons
         assert b in snn.neurons[0:3]
+        assert 1 in snn.neurons[0:3]
+        assert 3 not in snn.neurons[0:3]
+        assert None not in snn.neurons[0:3]
         print(snn.neurons[0::2][-2:-1])
         with self.assertRaises(IndexError):
             snn.neurons[6]
+        assert NeuronListView(snn, [0, 4, 3, 3, 3, 1]).indices == [0, 4, 3, 3, 3, 1]
+        with self.assertRaises(IndexError):
+            NeuronListView(snn, [0, 1, 5])
+        l1 = NeuronListView(snn, [0, 1, 2])
+        l2 = mlist([a, b, c])
+        l3 = asmlist([a, b, c])
+        assert l1 == l2
+        assert l1 == l3
+        assert l1 is not l2
+        assert l1 is not l3
+        assert l1[[0, 1]] == [a, b]
+        assert l1[[a, 1]] == [a, b]
+        with self.assertRaises(TypeError):
+            l1[[0, 'a']]
+        assert l1[0:1] == [a]
+        assert l1[0:1] != [None]
+        assert l1[0:1] != None  # not iterable  # noqa: E711
+        assert l1[0:1] != []
+        assert l1.tolist() == [a, b, c]
+
+    def test_neuronlist_empty(self):
+        """ Test if NeuronList works as expected """
+        print("begin test_neuronlist_empty")
+        snn = SNN()
+        a = snn.create_neuron()
+        empty = mlist([])
+        with self.assertRaises(RuntimeError):
+            empty.append(a)
+        assert len(empty) == 0
+        assert not empty
+        with self.assertRaises(IndexError):
+            assert not empty[0]
+
+    def test_neuronlistview_error(self):
+        """ Test if NeuronListView works as expected """
+        print("begin test_neuronlistview_error")
+
+        snn = SNN()
+        a = snn.create_neuron()
+        b = snn.create_neuron()
+        c = snn.create_neuron()
+        li = snn.neurons[:]
+
+        snn2 = SNN()
+        b2 = snn2.create_neuron()
+        li2 = snn2.neurons[:]
+
+        assert li[0] == a
+        with self.assertRaises(ValueError):
+            li[0] = b2  # neuron wrong model
+        with self.assertRaises(TypeError):
+            li[0] = "I'm not a Neuron"
+        with self.assertRaises(ValueError):
+            li[0:1] = li2  # listview wrong model
+        with self.assertRaises(ValueError):
+            li[0:3:2] = [b]  # extended slice
+        with self.assertRaises(ValueError):
+            li[[0]] = []  # wrong size
+        with self.assertRaises(ValueError):
+            li[[3]] = [c]  # invalid index
+
+        with self.assertRaises(ValueError):
+            li.append(b2)  # neuron wrong model
+        with self.assertRaises(ValueError):
+            li.append("I'm not a Neuron")
+        with self.assertRaises(ValueError):
+            li.insert(0, b2)  # neuron wrong model
+        with self.assertRaises(ValueError):
+            li.insert(0, "I'm not a Neuron")
+        with self.assertRaises(ValueError):
+            li.extend(li2)  # listview wrong model
 
     def test_neuronlistview_modify(self):
         """ Test if NeuronListView works as expected """
@@ -143,6 +284,21 @@ class NeuronTest(unittest.TestCase):
         assert vl == snn.neurons[:]
         vl[:6] = []
         assert vl == []
+        vl2 = snn.neurons[:2]
+        vl[0:1] = vl2
+        assert vl == vl2
+        vl[0] = b
+        assert vl == [b, b]
+        vl[1:1] = [c]
+        assert vl == [b, c, b]
+        del vl[1]
+        assert vl == [b, b]
+        del vl[0:2]
+        assert vl == []
+        with self.assertRaises(TypeError):
+            del vl[None]
+        with self.assertRaises(IndexError):
+            del vl[0]
 
     def test_create_listview(self):
         """ Test if creating listview works as expected """
@@ -164,6 +320,13 @@ class NeuronTest(unittest.TestCase):
 
         assert vl2 is vl
 
+        vl3 = NeuronListView(vl)
+        assert vl == vl3
+        assert vl is not vl3
+
+        with self.assertRaises(ValueError):
+            NeuronListView(None, [0, 1, 2])
+
     def test_neuron_cache(self):
         """ Test if neuron cache works as expected """
         print("begin test_neuron_cache")
@@ -183,6 +346,10 @@ class NeuronTest(unittest.TestCase):
 
         assert hash(a) == hash(snn.neurons[0])
         assert hash(b) == hash(snn.neurons[1])
+        with self.assertRaises(IndexError):
+            assert hash(a) != hash(snn.synapses[0])
+        snn.create_synapse(a, b)
+        assert hash(a) != hash(snn.synapses[0])
 
         assert a == snn.neurons[0]
         assert b == snn.neurons[1]

--- a/tests/test_neuron.py
+++ b/tests/test_neuron.py
@@ -174,6 +174,27 @@ class NeuronTest(unittest.TestCase):
         assert a is snn.neurons[0]
         assert b is snn.neurons[1]
 
+    def test_neuron_hashing(self):
+        """ Test if neuron hashing works as expected """
+        print("begin test_neuron_hashing")
+        snn = SNN()
+        a = snn.create_neuron()
+        b = snn.create_neuron()
+
+        assert hash(a) == hash(snn.neurons[0])
+        assert hash(b) == hash(snn.neurons[1])
+
+        assert a == snn.neurons[0]
+        assert b == snn.neurons[1]
+
+        assert a != b
+
+        d = {a: 0, b: 1}
+        assert d[a] == 0
+        assert d[b] == 1
+        assert a in d
+        assert b in d
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_neuron.py
+++ b/tests/test_neuron.py
@@ -164,6 +164,16 @@ class NeuronTest(unittest.TestCase):
 
         assert vl2 is vl
 
+    def test_neuron_cache(self):
+        """ Test if neuron cache works as expected """
+        print("begin test_neuron_cache")
+        snn = SNN()
+        a = snn.create_neuron()
+        b = snn.create_neuron()
+
+        assert a is snn.neurons[0]
+        assert b is snn.neurons[1]
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_synapse.py
+++ b/tests/test_synapse.py
@@ -166,6 +166,8 @@ class SynapseTest(unittest.TestCase):
 
         print("testing SynapseListView")
         print(snn.synapses)
+        assert snn.synapses[0] == ab
+        assert snn.synapses[ab].idx == 0
         assert snn.synapses[:] == [ab] + ac.delay_chain_synapses
         assert snn.synapses[0:2] == [ab, ac.delay_chain_synapses[0]]
         assert snn.synapses[2:4]
@@ -230,6 +232,7 @@ class SynapseTest(unittest.TestCase):
         ba = snn.create_synapse(b, a)
 
         assert hash(ab) == hash(snn.synapses[0])
+        assert hash(ab) != hash(snn.neurons[0])
         assert hash(ba) == hash(snn.synapses[1])
 
         synapse_set = {ab, ba}

--- a/tests/test_synapse.py
+++ b/tests/test_synapse.py
@@ -219,6 +219,28 @@ class SynapseTest(unittest.TestCase):
         assert [int(s) for s in synapse_chain] == [0, 1, 2]
         assert snn.synapses[0].delay_chain == []
 
+    def test_synapse_hashing(self):
+        """ Test if synapse hashing works as expected """
+        print("begin test_synapse_hashing")
+        snn = SNN()
+        a = snn.create_neuron()
+        b = snn.create_neuron()
+
+        ab = snn.create_synapse(a, b)
+        ba = snn.create_synapse(b, a)
+
+        assert hash(ab) == hash(snn.synapses[0])
+        assert hash(ba) == hash(snn.synapses[1])
+
+        synapse_set = {ab, ba}
+        assert ab in synapse_set
+        synapse_set.add(ab)
+        assert len(synapse_set) == 2
+
+        d = {ab: 0, ba: 1}
+        assert d[ab] == 0
+        assert d[ba] == 1
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
massively improve coverage of accessor classes, fix bugs

* Neuron/Synapse caching on model:
  * Neuron and Synapse objects will have a weakref stored on the model, to allow for the index of such objects to be changed in the event that a neuron is deleted or something, since deletion causes huge shifts in neuron/synapse indices.
  * Each Neuron/Synapse is now a Singleton with respect to its model and id pair. That is,
  
        a = Neuron(snn1, 1)
        a.foo = "bar"
        assert snn1.neurons[1].foo == "bar"
       
* NeuronListView and SynapseListView objects also now get a weakref to them stored on the model, to allow for the indices to be updated in the event of neurons or synapses being deleted from the SNN.
* The model can still be pickled; these weakrefs are turned into normal refs for pickling and then back into weakrefs when unpickling.
* The weakrefs of neuron/synapse/ListView instances in the model will allow for deletion of neurons and synapses while giving the user a sane way to refer to the same neurons/synapses from before the delete, since deletion causes huge shifts in neuron/synapse indices.

* allow numpy ints for indexing accessors
* allow NeuronListView, SynapseListView, ModelListView to be imported from superneuromat.*

* Ability to to create empty `ModelListIterator` or `ModelListViewIterator` (NeuronIterator/SynapseIterator/NeuronListviewIterator/etc) without a model

* bugfix: adding synapses to ListView or mixed-type list adding neurons instead
* new: ModelListView.__mul__
* bugfix: ModelListView.sort(key=) now works correctly
* bugfix: explicit __neq__ on ModelAcessorList and ModelListView
* bugfix: accessor hash now factors in the typename of itself, so a Neuron(snn1, 1) no longer matches hashes of Synapse(snn1, 1)
* bugfix: accessors now properly change model
* bugfix: creating a ModelListView(x: ModelListView) from another instance of a ListView works now.
* bugfix: ModelListView now updates listview cache on model swaps
* bugfix: fixed error on ModelListView.__getitem__ call when it's empty
* bugfix: fixed SynapseListView.__getitem__(idx: int) returning Neuron
* bugfix: ModelListView.__delitem__(slice) would perform list mutation during iteration, causing unexpected behavior.
* bugfix: fix incorrect return type for SynapseListView.pop()

* Change: Remove ability to index ModelListView[ModelAccessor]
* change: ModelListView.count now returns 0 instead of raising ValueError

- [x] >90% test coverage of accessor_classes.py
- [x] Better documentation