### PR TITLE
Resolve #35 by zeroing refractory periods on `reset()`

### DIFF
--- a/docs/source/api/SNN.rst
+++ b/docs/source/api/SNN.rst
@@ -65,37 +65,49 @@
 
    These attributes are not intended to be modified directly by end users.
 
-   :type neuron_thresholds: list
+   :type neuron_states: list[float]
+   :param neuron_states:
+      List of neuron states (charge or membrane potential)
+   :type neuron_thresholds: list[float]
    :param neuron_thresholds:
       List of neuron thresholds
-   :type neuron_leaks: list
+   :type neuron_leaks: list[float]
    :param neuron_leaks:
       List of neuron leaks
       defined as the amount by which the internal states of the neurons are pushed towards the neurons' reset states
-   :type neuron_reset_states: list
+   :type neuron_reset_states: list[float]
    :param neuron_reset_states:
-      List of neuron reset states
-   :type neuron_refractory_periods: list
+      List of neuron reset states.
+      This is the state of the neuron immediately after spiking.
+   :type neuron_refractory_periods: list[int]
    :param neuron_refractory_periods:
-      List of neuron refractory periods
-   :type pre_synaptic_neuron_ids: list
+      List of neuron refractory periods.
+      This is the number of time steps during which the neuron is in its refractory period.
+      When the neuron spikes, the ``neuron_refractory_periods_state`` is set to its value from ``neuron_refractory_periods``.
+   :type neuron_refractory_periods_state: list[int]
+   :param neuron_refractory_periods_state:
+      List of neuron refractory periods states
+      This is the countdown until the neuron is allowed to spike again.
+   :type pre_synaptic_neuron_ids: list[int]
    :param pre_synaptic_neuron_ids:
       List of pre-synaptic neuron IDs
-   :type post_synaptic_neuron_ids: list
+   :type post_synaptic_neuron_ids: list[int]
    :param post_synaptic_neuron_ids:
       List of post-synaptic neuron IDs
-   :type synaptic_weights: list
+   :type synaptic_weights: list[float]
    :param synaptic_weights:
       List of synaptic weights
-   :type synaptic_delays: list
+   :type synaptic_delays: list[int]
    :param synaptic_delays:
       List of synaptic delays
-   :type enable_stdp: list
+      Note that delay chain neurons are signified by a negative value on the final synapse in the chain.
+   :type enable_stdp: list[bool]
    :param enable_stdp:
       List of Boolean values denoting whether STDP learning is enabled on each synapse
-   :type input_spikes: dict
+   :type input_spikes: dict[int, dict[list[int], list[float]]]
    :param input_spikes:
       Dictionary of input spikes for each time step.
+      Indexed by ``time`` first, then a DoK-like sparse array of ``'nids'`` and ``'values'``.
 
 
 

--- a/docs/source/api/SNN.rst
+++ b/docs/source/api/SNN.rst
@@ -104,7 +104,7 @@
    :type enable_stdp: list[bool]
    :param enable_stdp:
       List of Boolean values denoting whether STDP learning is enabled on each synapse
-   :type input_spikes: dict[int, dict[list[int], list[float]]]
+   :type input_spikes: dict[int, dict[str, list]]
    :param input_spikes:
       Dictionary of input spikes for each time step.
       Indexed by ``time`` first, then a DoK-like sparse array of ``'nids'`` and ``'values'``.

--- a/docs/source/guide/managing_state.rst
+++ b/docs/source/guide/managing_state.rst
@@ -31,7 +31,7 @@ This is roughly equivalent to:
     the ``initial_state`` and ``refractory_state`` parameters of :py:meth:`create_neuron`.
     When ``reset()`` is called, if those states are not memoized, each neuron's charge
     state will be set to its reset state in :py:attr:`neuron_reset_states`,
-    and the refractory countdown in :py:attr:`neuron_refractory_periods` will be set to zero.
+    and the refractory countdown in :py:attr:`neuron_refractory_periods_state` will be set to zero.
 
     If this is not desirable, consider manually copying the parameters you care
     about so you can assign them later, or using :py:meth:`memoize` to store a snapshot

--- a/docs/source/guide/managing_state.rst
+++ b/docs/source/guide/managing_state.rst
@@ -8,7 +8,7 @@ Resetting the SNN
 -----------------
 
 Resetting the SNN is as simple as calling :py:meth:`~superneuromat.SNN.reset()`.
-By default, this will reset the neuron states, refractory periods, spike train, and input spikes.
+By default, this will reset the neuron states, zero refractory periods, spike train, and input spikes.
 
 .. code-block:: python
 
@@ -19,10 +19,24 @@ This is roughly equivalent to:
 .. code-block:: python
 
     snn.reset_neuron_states()
-    snn.reset_refractory_periods()
+    snn.zero_refractory_periods()
     snn.clear_spike_train()
     snn.clear_input_spikes()
     snn.restore()
+
+.. warning::
+
+    This method does not reset the synaptic weights or STDP parameters.
+    SuperNeuroMAT also does not automatically store the initial neuron state values, such as
+    the ``initial_state`` and ``refractory_state`` parameters of :py:meth:`create_neuron`.
+    When ``reset()`` is called, if those states are not memoized, each neuron's charge
+    state will be set to its reset state in :py:attr:`neuron_reset_states`,
+    and the refractory countdown in :py:attr:`neuron_refractory_periods` will be set to zero.
+
+    If this is not desirable, consider manually copying the parameters you care
+    about so you can assign them later, or using :py:meth:`memoize` to store a snapshot
+    to return to when :py:meth:`restore()` or :py:meth:`reset()` is called, or manually
+    calling only the individual functions that you need (shown above).
 
 If you want more granular control, you can call the individual methods:
 
@@ -32,18 +46,23 @@ If you want more granular control, you can call the individual methods:
     :nosignatures:
 
     ~superneuromat.SNN.reset_neuron_states
-    ~superneuromat.SNN.reset_refractory_periods
+    ~superneuromat.SNN.zero_refractory_periods
     ~superneuromat.SNN.clear_spike_train
     ~superneuromat.SNN.clear_input_spikes
     ~superneuromat.SNN.restore
 
+.. rubric:: Related Functions
+
+.. autosummary::
+    :nosignatures:
+
     ~superneuromat.SNN.reset
     ~superneuromat.SNN.zero_neuron_states
-    ~superneuromat.SNN.zero_refractory_periods
+    ~superneuromat.SNN.activate_all_refractory_periods
 
 .. note::
 
-    Without any other action, the :py:attr:`~superneuromat.SNN.synaptic_weights` cannot be reset
+    By default, the :py:attr:`~superneuromat.SNN.synaptic_weights` are not reset
     by the :py:meth:`~superneuromat.SNN.reset()` function. If you want to reset the weights, you
     must first save them by memoizing them.
 

--- a/src/superneuromat/neuromorphicmodel.py
+++ b/src/superneuromat/neuromorphicmodel.py
@@ -1587,7 +1587,7 @@ class SNN:
         """
         # De-vectorize from numpy arrays to lists
         self.neuron_states: list[float] = self._internal_states.tolist()
-        self.neuron_refractory_periods_state: list[float] = self._neuron_refractory_periods.tolist()
+        self.neuron_refractory_periods_state: list[int] = self._neuron_refractory_periods.tolist()
 
         # Update weights if STDP was enabled
         if self._do_stdp:
@@ -1738,7 +1738,7 @@ class SNN:
             the ``initial_state`` and ``refractory_state`` parameters of :py:meth:`create_neuron`.
             When ``reset()`` is called, if those states are not memoized, each neuron's charge
             state will be set to its reset state in :py:attr:`neuron_reset_states`,
-            and the refractory countdown in :py:attr:`neuron_refractory_periods` will be set to zero.
+            and the refractory countdown in :py:attr:`neuron_refractory_periods_state` will be set to zero.
 
             If this is not desirable, consider manually copying the parameters you care
             about so you can assign them later, or using :py:meth:`memoize` to store a snapshot

--- a/src/superneuromat/neuromorphicmodel.py
+++ b/src/superneuromat/neuromorphicmodel.py
@@ -1726,22 +1726,39 @@ class SNN:
         .. code-block:: python
 
             snn.reset_neuron_states()
-            snn.reset_refractory_periods()
+            snn.zero_refractory_periods()
             snn.clear_spike_train()
             snn.clear_input_spikes()
+            snn.restore()
 
         .. warning::
 
             This method does not reset the synaptic weights or STDP parameters.
-            Instead, consider copying the parameters you care about so you can assign them later.
+            SuperNeuroMAT also does not automatically store the initial neuron state values, such as
+            the ``initial_state`` and ``refractory_state`` parameters of :py:meth:`create_neuron`.
+            When ``reset()`` is called, if those states are not memoized, each neuron's charge
+            state will be set to its reset state in :py:attr:`neuron_reset_states`,
+            and the refractory countdown in :py:attr:`neuron_refractory_periods` will be set to zero.
+
+            If this is not desirable, consider manually copying the parameters you care
+            about so you can assign them later, or using :py:meth:`memoize` to store a snapshot
+            to return to when :py:meth:`restore()` or :py:meth:`reset()` is called, or manually
+            calling only the individual functions that you need (shown above).
 
             See :ref:`reset-snn` for more information.
 
+        See Also
+        --------
+        reset_neuron_states : Reset the charge states of all neurons to their reset values.
+        zero_refractory_periods : Reset the refractory period countdowns to zero.
+        clear_spike_train : Delete all recorded spike trains.
+        clear_input_spikes : Delete all queued input spikes.
+        restore : Restore the model variables to their memoized states.
         """
         if 'neuron_states' not in self.memoized:
             self.reset_neuron_states()
         if 'neuron_refractory_periods_state' not in self.memoized:
-            self.activate_all_refractory_periods()
+            self.zero_refractory_periods()
         if 'spike_train' not in self.memoized:
             self.clear_spike_train()
         if 'input_spikes' not in self.memoized:
@@ -1749,7 +1766,7 @@ class SNN:
         self.restore()
 
     def restore(self, *args):
-        """Restore model variables to their memoized states.
+        """Restore all or some model variables to their memoized states.
 
         Parameters
         ----------


### PR DESCRIPTION
Makes the `SNN.reset()` function zero the refractory periods instead of activating them, resolving #35 properly.

Also, update docs:
* `reset()` docstring in [`src/superneuromat/neuromorphicmodel.py`](/src/superneuromat/neuromorphicmodel.py)
* [`docs/source/guide/managing_state.rst`](/docs/source/guide/managing_state.rst)